### PR TITLE
Generate table of results

### DIFF
--- a/framework/demo.py
+++ b/framework/demo.py
@@ -27,28 +27,32 @@ def include_tests(cls):
 
 @ddt
 @include_tests
-class TestName(unittest.TestCase):
+class TestClass(unittest.TestCase):
     pass
 
-suite = unittest.TestLoader().loadTestsFromTestCase(TestName)
+suite = unittest.TestLoader().loadTestsFromTestCase(TestClass)
 results = unittest.TextTestRunner(stream=sys.stdout, verbosity=2).run(suite)
 
-failures = [failure[0].id() for failure in results.failures]
+# Generate a table of results. The table contains True if the test was
+# failed for a data point (consistent with how a mask is defined in 
+# numpy masked arrays).
 nTests = len(testNames)
 nData  = results.testsRun / nTests
-
-testNameIndices = dict.fromkeys(testNames)
-for iName, name in enumerate(testNames): testNameIndices[name] = iName
-print testNameIndices
 table = np.ndarray([nTests, nData], dtype=bool)
 table[:, :] = False
-for failure in failures:
-    pos = failure.find('TestName.test_')
-    failure = failure[pos + 14:]
-    pos = failure.rfind('_')
-    failureName = failure[:pos]
-    failureData = failure[pos+1:]
-    table[testNameIndices[failureName], failureData] = True
+
+testNameIndices = {}
+for iName, name in enumerate(testNames): 
+    testNameIndices[name] = iName
+
+failedTests = [failure[0].id() for failure in results.failures]
+for failedTest in failedTests:
+    pos = failedTest.find('TestClass.test_')
+    failedTest = failedTest[pos + 15:]
+    pos = failedTest.rfind('_')
+    failureName = failedTest[:pos]
+    failureData = failedTest[pos+1:]
+    table[testNameIndices[failureName], int(failureData)] = True
 
 for i, name in enumerate(testNames):
     print name, table[i, :]


### PR DESCRIPTION
The results from the unittest suite are parsed to determine which tests failed for which data points and a table generated (issue #11).
