### PR TITLE
ddt patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ AutoQC relies on [ddt](https://github.com/txels/ddt) to run over datasets:
 
 To execute the test suite,
 `python demo.py`
+
+
+##Notes
+ - `ddt` is patched here to not append data serializations to the ends of test names.

--- a/framework/demo.py
+++ b/framework/demo.py
@@ -61,8 +61,8 @@ for failedTest in failedTests:
     failedTest = failedTest[pos + 15:]
     pos = failedTest.rfind('_')
     failureName = failedTest[:pos]
-    failureData = failedTest[pos+1:]
-    table[testNameIndices[failureName], int(failureData)-1] = True
+    failureIndex = failedTest[pos+1:]
+    table[testNameIndices[failureName], int(failureIndex)-1] = True
 
 for i, name in enumerate(testNames):
     print name, table[i, :]


### PR DESCRIPTION
`ddt` has the somewhat unfortunate default behavior of suffixing test names with a string serialization of the data being run over; this reeks of disaster when we start putting giant strings of real data in.  This pull patches this behavior, so tests are named `test_[name]_[index]` (is the same as default, but with no data serialization on the end).

fixes #11
