### PR TITLE
Fix for patching of ddt and added ddt version requirement to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Recently, an international team of researchers has decided to work together to b
 The IQuOD proposal is to set up an open quality control benchmarking system.  Work will begin by using python's `unittest` module to implement a battery of simple tests to run on some test data, and producing summary statistics and visualizations of the results.  Later goals include helping researchers either wrap their existing C, Fortran and Matlab test functions in Python for use in this test suite, or re-implementing those tests in native Python.
 
 ##Setup
-AutoQC relies on [ddt](https://github.com/txels/ddt) to run over datasets:
+AutoQC relies on [ddt](https://github.com/txels/ddt) (v0.8.0) to run over datasets:
 `sudo pip install ddt`
 
 To execute the test suite,

--- a/framework/demo.py
+++ b/framework/demo.py
@@ -2,9 +2,10 @@ import glob
 import unittest
 import sys
 import os
-from ddt import ddt, FILE_ATTR
+import ddt
 import tests
 import numpy as np
+import re
 
 dir = os.path.dirname(__file__)
 datafile = os.path.join(dir, '../data/demo.json')
@@ -19,6 +20,7 @@ def mk_test_name(name, value, index=0):
         value = value.encode('ascii', 'backslashreplace')
     test_name = "{0}_{1}".format(name, index + 1)
     return re.sub('\W|^(?=\d)', '_', test_name)
+ddt.mk_test_name = mk_test_name
 
 # Find all QC subroutines.
 testFiles = glob.glob('tests/[!_]*.py')
@@ -31,11 +33,11 @@ def include_tests(cls):
     for testName in testNames:
         exec('import tests.' + testName)
         exec('def test_' + testName + '(self, value): self.assertTrue(tests.' + testName + '.test(value))')
-        exec('setattr(test_' + testName + ', FILE_ATTR, datafile)')
+        exec('setattr(test_' + testName + ', ddt.FILE_ATTR, datafile)')
         exec('cls.test_' + testName + ' = test_' + testName)
     return cls
 
-@ddt
+@ddt.ddt
 @include_tests
 class TestClass(unittest.TestCase):
     pass


### PR DESCRIPTION
The patch for ddt didn't work for me as it was, but on checking the revision history I noticed that a line had been missed out of the final version.

I also added the version number needed for ddt as previous versions name the tests differently.
