### PR TITLE
Bug fix for issue with reading WOD data with missing data

### DIFF
--- a/dataio/wod.py
+++ b/dataio/wod.py
@@ -299,9 +299,9 @@ class WodProfile(object):
                 self._interpret_data(fid, copy.deepcopy(vFormat1), data[i]['variables'][j])
                 if ('Value' in data[i]['variables'][j]):
                     data[i]['variables'][j]['Missing'] = False
+                    self._interpret_data(fid, copy.deepcopy(vFormat2), data[i]['variables'][j])
                 else:
                     data[i]['variables'][j]['Missing'] = True
-                self._interpret_data(fid, copy.deepcopy(vFormat2), data[i]['variables'][j])
 
         self.profile_data = data
         return None


### PR DESCRIPTION
If there was a missing data value the WOD ASCII reader was breaking because it tried to read some information that it shouldn't. This change prevents this from happening.
