### PR TITLE
began adding simple asserts to functions in AutoQC.py

### DIFF
--- a/AutoQC.py
+++ b/AutoQC.py
@@ -79,9 +79,9 @@ def referenceResults(profiles):
   for profile in profiles:
     refAssessment = profile.t_level_qc(originator=True) >= 3
 
-    #demand reference results returned bools:
+    #demand reference results returned bools, or masked constants for missing values:
     for i in refAssessment:
-      assert isinstance(i, np.bool_), str(i) + ' in reference result list is of type ' + str(type(i))
+      assert isinstance(i, np.bool_) or isinstance(i, np.ma.core.MaskedConstant), str(i) + ' in reference result list is of type ' + str(type(i))
 
     refResult.append(np.ma.any(refAssessment))
     verbose.append(refAssessment)
@@ -90,7 +90,7 @@ def referenceResults(profiles):
 def generateLogfile(verbose, trueVerbose, profiles, testNames):
   '''
   verbose[i][j][k] == result of test i on profile j at depth k
-  trueVerbose[i][j] == true result for profile i at depth j
+  trueVerbose[j][k] == true result for profile j at depth k
   <profiles> == array of profiles per `extractProfiles`
   <testNames> == array of names returned by `importQC`
   '''


### PR DESCRIPTION
Started adding some simple assertion checks to the functions used in `AutoQC.py`, when I came across something I don't understand. The `assert` I have written for `refereceResults` insists that all reference results be numpy booleans; this assertion raises exceptions, since several of them are of type `<class 'numpy.ma.core.MaskedConstant'>`. This may in fact be correct, but my misunderstanding - @s-good, do you know why we'd be getting masked constants and not `True` or `False` for some of the reference results?

If indeed all is well, let me know before merging this pull, and I'll amend it with a more appropriate assertion test. 