### PR TITLE
first pass at Argo spike for #25

### DIFF
--- a/qctests/Argo_spike_test.py
+++ b/qctests/Argo_spike_test.py
@@ -1,0 +1,39 @@
+"""
+Implements the spike test on page 8 of http://w3.jcommops.org/FTPRoot/Argo/Doc/argo-quality-control-manual.pdf
+"""
+
+import numpy
+
+def test(p):
+    """
+    Runs the quality control check on profile p and returns a numpy array
+    of quality control decisions with False where the data value has
+    passed the check and True where it failed.
+    """
+
+    # Get temperature values from the profile.
+    t = p.t()
+    # Get depth values (m) from the profile.
+    d = p.z()
+
+    assert len(t.data) == len(d.data), 'Number of temperature measurements does not equal number of depth measurements.'
+
+    # initialize qc as a bunch of falses;
+    # implies all measurements pass when a spike can't be calculated, such as at edges & gaps in data:
+    qc = numpy.zeros(len(t.data), dtype=bool)
+
+    # check for gaps in data
+    isTemperature = (t.mask==False)
+    isDepth = (d.mask==False)
+    isData = isTemperature & isDepth
+
+    for i in range(1,len(t.data)-1):
+        if isData[i] & isTemperature[i-1] & isTemperature[i+1]:
+
+          isSpike = numpy.abs(t.data[i] - (t.data[i-1] + t.data[i+1])/2) - numpy.abs((t.data[i+1] - t.data[i-1])/2)
+          if d.data[i] < 500:
+              qc[i] = isSpike > 6.0
+          else:
+              qc[i] = isSpike > 2.0
+
+    return qc


### PR DESCRIPTION
Here's a run at the Argo spike test for temperature, requested in #25 - a couple of things to note:

 - I took the issue dead literally, by interpreting pressure in db described in the reference as depth in meters.
 - This test will always pass the first and last measurements in a profile, since the spike test relies on having a measurement both before and after.
 - This test demands that both temperature and depth info be available for the measurement in question, as well as the temperature one step before and one step after (for the purposes of calculating the spike). If any of these demands are not satisfied, no exception is raised for that measurement. 