### PR TITLE
Gradient Tests

### DIFF
--- a/AutoQC.py
+++ b/AutoQC.py
@@ -228,7 +228,7 @@ print('Number of profiles that should have been failed was %i' % np.sum(trueResu
 bmResults = benchmarks.compare_to_truth(combos, trueResult)
 
 # Plot the results.
-benchmarks.plot_roc(bmResults)
+#benchmarks.plot_roc(bmResults)
 
 #logfile
-generateLogfile(verbose, trueVerbose, profiles, testNames)
+#generateLogfile(verbose, trueVerbose, profiles, testNames)

--- a/qctests/Argo_gradient_test.py
+++ b/qctests/Argo_gradient_test.py
@@ -1,0 +1,39 @@
+"""
+Implements the gradient test on page 8 of http://w3.jcommops.org/FTPRoot/Argo/Doc/argo-quality-control-manual.pdf
+"""
+
+import numpy
+
+def test(p):
+    """
+    Runs the quality control check on profile p and returns a numpy array
+    of quality control decisions with False where the data value has
+    passed the check and True where it failed.
+    """
+
+    # Get temperature values from the profile.
+    t = p.t()
+    # Get depth values (m) from the profile.
+    d = p.z()
+
+    assert len(t.data) == len(d.data), 'Number of temperature measurements does not equal number of depth measurements.'
+
+    # initialize qc as a bunch of falses;
+    # implies all measurements pass when a gradient can't be calculated, such as at edges & gaps in data:
+    qc = numpy.zeros(len(t.data), dtype=bool)
+
+    # check for gaps in data
+    isTemperature = (t.mask==False)
+    isDepth = (d.mask==False)
+    isData = isTemperature & isDepth
+
+    for i in range(1,len(t.data)-1):
+        if isData[i] & isTemperature[i-1] & isTemperature[i+1]:
+
+          isSlope = numpy.abs(t.data[i] - (t.data[i-1] + t.data[i+1])/2)
+          if d.data[i] < 500:
+              qc[i] = isSlope > 9.0
+          else:
+              qc[i] = isSlope > 3.0
+
+    return qc

--- a/qctests/WOD_gradient_check.py
+++ b/qctests/WOD_gradient_check.py
@@ -1,0 +1,44 @@
+"""
+Implements the excessive gradient test on page 47 of http://data.nodc.noaa.gov/woa/WOD/DOC/wodreadme.pdf
+"""
+
+import numpy
+
+def test(p):
+    """
+    Runs the quality control check on profile p and returns a numpy array
+    of quality control decisions with False where the data value has
+    passed the check and True where it failed.
+    """
+
+    # Get temperature values from the profile.
+    t = p.t()
+    # Get depth values (m) from the profile.
+    d = p.z()
+
+    assert len(t.data) == len(d.data), 'Number of temperature measurements does not equal number of depth measurements.'
+
+    # initialize qc as a bunch of falses;
+    # implies all measurements pass when a gradient can't be calculated, such as at edges & gaps in data:
+    qc = numpy.zeros(len(t.data), dtype=bool)
+
+    # check for gaps in data
+    isTemperature = (t.mask==False)
+    isDepth = (d.mask==False)
+    isData = isTemperature & isDepth
+
+    for i in range(0,len(t.data)-1):
+        if isData[i] & isData[i+1] & (d.data[i+1] - d.data[i] > 0):
+
+          gradient = (t.data[i+1] - t.data[i]) / (d.data[i+1] - d.data[i])
+
+          # gradient check
+          qc[i] = (gradient > 0.3) or (gradient < -0.7)
+
+          # zero sensitivity indicator
+          # flags data if temperature drops to 0 too abruptly, indicating a missing value.
+          if t.data[i] == 0:
+              if -1.0 * gradient > 5.0 * 0.7:
+                  qc[i] = True
+
+    return qc

--- a/qctests/WOD_gradient_check.py
+++ b/qctests/WOD_gradient_check.py
@@ -33,12 +33,13 @@ def test(p):
           gradient = (t.data[i+1] - t.data[i]) / (d.data[i+1] - d.data[i])
 
           # gradient check
-          qc[i] = (gradient > 0.3) or (gradient < -0.7)
+          qc[i] = (gradient > 0.3) or (gradient < -0.7) or qc[i] # in case qc[i] was set true by the zero sensitivity indicator in the previous step
+          qc[i+1] = (gradient > 0.3) or (gradient < -0.7)
 
           # zero sensitivity indicator
           # flags data if temperature drops to 0 too abruptly, indicating a missing value.
-          if t.data[i] == 0:
+          if t.data[i+1] == 0:
               if -1.0 * gradient > 5.0 * 0.7:
-                  qc[i] = True
+                  qc[i+1] = True
 
     return qc

--- a/qctests/WOD_gradient_check.py
+++ b/qctests/WOD_gradient_check.py
@@ -30,7 +30,7 @@ def test(p):
     for i in range(0,len(t.data)-1):
         if isData[i] & isData[i+1] & (d.data[i+1] - d.data[i] > 0):
 
-          gradient = (t.data[i+1] - t.data[i]) / (d.data[i+1] - d.data[i])
+          gradient = (t.data[i+1] - t.data[i]) / max([ (d.data[i+1] - d.data[i]) , 3.0])
 
           # gradient check
           qc[i] = (gradient > 0.3) or (gradient < -0.7) or qc[i] # in case qc[i] was set true by the zero sensitivity indicator in the previous step


### PR DESCRIPTION
This PR contains first passes at the checks in #26 and #27. Notes:

 - Both follow the previous implementation of `Argo_spike_test.py` and its assumptions.
 - `WOD_gradient_check.py` adds a constraint that demands the depths of neighboring measurements not be identical (in order to avoid dividing by 0 in the gradient). But, the text mentions requiring neighboring measurements be separated by at least 3 m in the case of high-resolution instruments; that would also solve the divide-by-0 problem, but it isn't immediately clear to me if this constraint can be required generally, or, perhaps better, if and how the profile object indicates whether it was a 'high resolution' measurement or not.
 - Turned off the verbose logging temporarily, as the combinatorics grow. 
 - `WOD_gradient_check.py` also includes the check described in the text to attempt to distinguish between 0 as a number and 0 as a missing value indicator. Are we accommodating 0 as a missing value indicator? If not, might as well drop this part of the test. 

