### PR TITLE
illustrates proposal for qctest validation suggested in #41

### DIFF
--- a/qcvalidation.py
+++ b/qcvalidation.py
@@ -1,0 +1,17 @@
+import qctests.EN_range_check
+import util.testingProfile
+import numpy
+
+def test_EN_range_check_spotcheck():
+    '''
+    Spot-check the implementaion of EN_range_check.
+    '''
+
+    p = util.testingProfile.fakeProfile([1,1000,1], [100,200,300])
+
+    qc = qctests.EN_range_check.test(p)
+
+    truth = numpy.zeros(3, dtype=bool)
+    truth[1] = True
+
+    assert numpy.array_equal(qc, truth)

--- a/util/testingProfile.py
+++ b/util/testingProfile.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+class fakeProfile:
+    '''
+    generate a fake simplified profile in order to test 
+    implementations of qc-tests.
+    '''
+
+    def __init__(self, temperatures, depths):
+        self.temperatures = temperatures
+        self.depths = depths
+
+    def t(self):
+        """ Returns a numpy masked array of temperatures. """
+        return self.var_data(self.temperatures)
+
+    def z(self):
+        """ Returns a numpy masked array of depths. """
+        return self.var_data(self.depths)
+
+    def var_data(self, dat):
+        """ Returns the data values for a variable given the variable index. """
+        data = np.ma.array(np.zeros(len(dat)), mask=True)
+
+        for i in range(len(dat)):
+            data[i] = dat[i]
+        return data
+


### PR DESCRIPTION
As I was mentioning in #41, we'd like to be able to run some sanity checks on our implementations of the qc-tests, particularly for the more sophisticated ones like in #28. `util/testingProfile.py` creates a dummy class that mimics the WOD profile class, into which can be passed arbitrary arrays of temperature and depth data to create fake profiles designed to pass or fail a given qc test.

running `nosetests qcvalidation.py` at top level will run this validation; currently only one trivial check is implemented, but if the strategy seems sound we can go ahead and implement more serious validation checks.