### PR TITLE
Updates to allow running the tests on a very large number of profiles…

### DIFF
--- a/dataio/wod.py
+++ b/dataio/wod.py
@@ -25,7 +25,7 @@ class WodProfile(object):
             profile2.is_last_profile_in_file() # Is this the last profile?
             fid.close()
     """
-    def __init__(self, fid):
+    def __init__(self, fid, load_profile_data=True):
 
         # Record of where the profile occurs.
         self.file_name = fid.name
@@ -49,7 +49,10 @@ class WodProfile(object):
             self._read_taxonomic_data(fid)
         else:
             self.taxa = {}
-        self._read_profile_data(fid)
+        if load_profile_data:
+            self._read_profile_data(fid)
+        else:
+            self.profile_data = []
 
         # Wind forward to the next profile in the file.
         self.advance_file_position_to_next_profile(fid)

--- a/qctests/EN_spike_and_step_check.py
+++ b/qctests/EN_spike_and_step_check.py
@@ -45,6 +45,8 @@ def test(p, *args, **kwargs):
                 continue
             if z[i] - z[i-2] >= 5.0:
                 wt1 = (z[i-1] - z[i-2]) / (z[i] - z[i-2])
+            else:
+                wt1 = 0.5
         else:
             if (isData[i-1] and isData[i]) == False:
                 continue
@@ -70,10 +72,13 @@ def test(p, *args, **kwargs):
     # End of loop over levels.
     
     # Step or 0.0 at the bottom of a profile.
-    if dt.mask[-1] and np.abs(dt[-1]) > dTTol:
-        qc[-1] = True
-    if t[-1] == 0.0:
-        qc[-1] = True
+    if isData[-1] and dt.mask[-1] == False:
+        dTTol = determineDepthTolerance(z[-1], np.abs(p.latitude()))
+        if np.abs(dt[-1]) > dTTol:
+            qc[-1] = True
+    if isTemperature[-1]:
+        if t[-1] == 0.0:
+            qc[-1] = True
         
     # If 4 levels or more than half the profile is rejected then reject all.
     nRejects = np.count_nonzero(qc)
@@ -91,7 +96,7 @@ def composeDT(var, z, nLevels):
     dt.mask = True
     gt = dt.copy()
 
-    for i in range(nLevels):
+    for i in range(1, nLevels):
         if ((z[i] - z[i-1]) <= 50.0 or 
             (z[i] >= 350.0 and (z[i] - z[i-1]) <= 100.0)):
             dt[i] = var[i] - var[i-1]

--- a/util/benchmarks.py
+++ b/util/benchmarks.py
@@ -65,9 +65,18 @@ def plot_roc(bmResults):
     tpr = np.array([bmResults[i][1][1] for i in range(len(bmResults))])
     dists = np.sqrt(fpr**2 + (100.0 - tpr)**2)
 
-    lFpr  = fpr == np.min(fpr)
-    lTpr  = tpr == np.max(tpr)
+    lFpr  = fpr == np.min(fpr[tpr > 0]) # Ignore if no good rejects are made.
+    lTpr  = tpr == np.max(tpr[fpr < 100]) # Ignore if all good projiles are rejected.
     lDist = dists == np.min(dists)
+
+    # Select the combinations using the fewest tests.
+    nComb = []
+    for bm in bmResults:
+        nComb.append(np.sum([len(sublist) for sublist in bm[0]]))
+    nComb = np.array(nComb)
+    lFpr  = lFpr & (nComb == np.min(nComb[lFpr]))
+    lTpr  = lTpr & (nComb == np.min(nComb[lTpr]))
+    lDist = lDist & (nComb == np.min(nComb[lDist]))
 
     for num, bm in enumerate(bmResults):
         printout = False


### PR DESCRIPTION
… without running out of memory. Also a couple of changes to make the EN_spike_and_step_check more robust and to improve the output from the benchmarking code.

Results from the 150 profile test dataset available in the repository are the same as before. Results when running on the full test dataset are:

155794 profiles will be read
7 quality control checks will be applied:
 Argo_global_range_check
 Argo_gradient_test
 Argo_pressure_increasing_test
 Argo_spike_test
 EN_range_check
 EN_spike_and_step_check
 WOD_gradient_check
Number of profiles tested was 155787
Number of profiles that failed Argo_global_range_check was 2560
Number of profiles that failed Argo_gradient_test was 4331
Number of profiles that failed Argo_pressure_increasing_test was 7514
Number of profiles that failed Argo_spike_test was 1031
Number of profiles that failed EN_range_check was 2351
Number of profiles that failed EN_spike_and_step_check was 7198
Number of profiles that failed WOD_gradient_check was 8201
Number of profiles that should have been failed was 18174

Previously the code would not run on this number of profiles without running out of memory. 