### PR TITLE
Impossible date time

### DIFF
--- a/qctests/Argo_impossible_date_test.py
+++ b/qctests/Argo_impossible_date_test.py
@@ -29,5 +29,7 @@ def test(p, **kwargs):
         qc[0] = True
     elif day not in range(1, calendar.monthrange(year, month)[1] + 1):
         qc[0] = True
+    elif time is not None and (time < 0 or time >= 24):
+        qc[0] = True
 
     return qc

--- a/qctests/Argo_impossible_date_test.py
+++ b/qctests/Argo_impossible_date_test.py
@@ -18,7 +18,7 @@ def test(p, **kwargs):
     year = p.year()
     month = p.month()
     day = p.day()
-    #time = p.time()
+    time = p.time()
 
     # initialize qc as false:
     qc = numpy.zeros(1, dtype=bool)

--- a/tests/Argo_impossible_date_test_validation.py
+++ b/tests/Argo_impossible_date_test_validation.py
@@ -43,3 +43,23 @@ def test_Argo_impossible_date_test_day_leap_year():
     qc = qctests.Argo_impossible_date_test.test(p)
     truth = numpy.zeros(1, dtype=bool)
     assert numpy.array_equal(qc, truth), 'Argo impossible date test not correctly identifying leap years'
+
+def test_Argo_impossible_date_test_hour():
+    '''
+    hour range in impossible date test
+    '''
+    p = util.testingProfile.fakeProfile([0], [0], date=[2004, 2, 29, 24]) 
+    qc = qctests.Argo_impossible_date_test.test(p)
+    truth = numpy.zeros(1, dtype=bool)
+    truth[0] = True
+    assert numpy.array_equal(qc, truth), 'Argo impossible date test not correctly flagging an out of range time; times fall on [0,24)'    
+
+def test_Argo_impossible_date_test_hour_missing():
+    '''
+    pass the dataset if the time is missing
+    '''
+    p = util.testingProfile.fakeProfile([0], [0], date=[2004, 1, 29, None]) 
+    qc = qctests.Argo_impossible_date_test.test(p)
+    truth = numpy.zeros(1, dtype=bool)
+
+    assert numpy.array_equal(qc, truth), 'Argo impossible date test not correctly handling missing time data.' 

--- a/util/testingProfile.py
+++ b/util/testingProfile.py
@@ -17,6 +17,7 @@ class fakeProfile:
         self.primary_header['Year'] = date[0]
         self.primary_header['Month'] = date[1]
         self.primary_header['Day'] = date[2]
+        self.primary_header['Time'] = date[3]
         
     def latitude(self):
         """ Returns the latitude of the profile. """
@@ -51,6 +52,10 @@ class fakeProfile:
     def day(self):
         """ Returns the day. """
         return self.primary_header['Day']
+
+    def time(self):
+        """ Returns the time. """
+        return self.primary_header['Time']
 
     def var_data(self, dat):
         """ Returns the data values for a variable given the variable index. """


### PR DESCRIPTION
Implemented the time check on `Argo_impossible_date` from #51 - but, I'm a little unclear on how the wod format is encoding times. It looks like times are floats on the range 0 to 24, so the condition in the [text](http://w3.jcommops.org/FTPRoot/Argo/Doc/argo-quality-control-manual.pdf) that requires a plausible hour and minute are interpreted here as the time returned from the profile being on that range. Let me know if there's a problem with this interpretation.