### PR TITLE
faster travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 language: python
 python:
   - "2.7"
-# install dependencies
+# Setup anaconda
+before_install:
+  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - chmod +x miniconda.sh
+  - ./miniconda.sh -b
+  - export PATH=/home/travis/miniconda/bin:$PATH
+  - conda update --yes conda
+  - travis_retry conda install --yes python=$TRAVIS_PYTHON_VERSION Shapely netCDF4 matplotlib numpy scipy scikit-learn
+# non-native conda deps:
 install:
   - sudo apt-get install libhdf5-serial-dev libnetcdf-dev
-  - pip install -r requirements.txt
-# command to run tests
+  - conda install -y -c https://conda.binstar.org/jjhelmus pyproj
 script: nosetests tests/*.py


### PR DESCRIPTION
this is the travis build script from #79 - merging it in ahead of that work, since the anaconda install is several minutes faster than pip'ing everything.