### PR TITLE
EN_track_check

### DIFF
--- a/AutoQC.py
+++ b/AutoQC.py
@@ -33,9 +33,11 @@ def processFile(fName):
   firstProfile = True
   currentFile  = ''
   f = None
-  for iprofile, pinfo in enumerate(profiles):
-    # Do not process data twice if run in parallel.
-    if pinfo.file_name != fName: continue 
+
+  # keep a list of only the profiles in this thread
+  data.ds.threadProfiles = main.extractProfiles([fName])
+
+  for iprofile, pinfo in enumerate(data.ds.threadProfiles):
     # Load the profile data.
     p, currentFile, f = main.profileData(pinfo, currentFile, f)
     # Check that there are temperature data in the profile, otherwise skip.

--- a/qctests/EN_track_check.py
+++ b/qctests/EN_track_check.py
@@ -15,8 +15,8 @@ import math
 DistRes = 20000. # meters
 TimeRes = 600. # seconds
 
-ds.EN_track_headers = {}
-ds.EN_track_results = {}
+EN_track_headers = {}
+EN_track_results = {}
 
 def test(p):
     """ 
@@ -35,25 +35,25 @@ def test(p):
     # qc return objects) 
 
     # check if this profile has been examined already
-    if (cruise, uid) in ds.EN_track_results.keys():
-        return ds.EN_track_results[(cruise, uid)]
+    if (cruise, uid) in EN_track_results.keys():
+        return EN_track_results[(cruise, uid)]
 
     # some detector types cannot be assessed by this test; do not raise flag.
     if p.probe_type in [None,0]:
         return np.zeros(1, dtype=bool)
 
-    # the first time this test is run, sort ds.profiles into a cruise-keyed dictionary:
-    if ds.EN_track_headers == {}:
-        ds.EN_track_headers = main.sort_headers(ds.profiles)
+    # the first time this test is run, sort ds.threadProfiles into a cruise-keyed dictionary:
+    if EN_track_headers == {}:
+        EN_track_headers = main.sort_headers(ds.threadProfiles)
 
     # since we didn't find an answer already calculated,
     # we still need to do the calculation for this cruise;
-    # all the relevant headers are sitting in the ds.EN_track_headers list.
-    headers = ds.EN_track_headers[cruise]
+    # all the relevant headers are sitting in the EN_track_headers list.
+    headers = EN_track_headers[cruise]
 
     # start all as passing by default:
     for i in range(len(headers)):
-        ds.EN_track_results[(headers[i].cruise(), headers[i].uid())] = np.zeros(1, dtype=bool)
+        EN_track_results[(headers[i].cruise(), headers[i].uid())] = np.zeros(1, dtype=bool)
 
     # copy the list of headers;
     # remove entries as they are flagged.
@@ -67,9 +67,9 @@ def test(p):
     # if more than half got rejected, reject everyone
     if len(passedHeaders) < len(headers) / 2:
         for i in range(len(headers)):
-            ds.EN_track_results[(headers[i].cruise(), headers[i].uid())][0] = True        
+            EN_track_results[(headers[i].cruise(), headers[i].uid())][0] = True        
 
-    return ds.EN_track_results[(cruise, uid)]
+    return EN_track_results[(cruise, uid)]
 
 def findOutlier(headers):
     '''
@@ -95,7 +95,7 @@ def findOutlier(headers):
     if flag:
         rejects = chooseReject(headers, speeds, angles, iMax, maxSpeed)
         for reject in rejects:
-            ds.EN_track_results[(headers[reject].cruise(), headers[reject].uid())][0] = True
+            EN_track_results[(headers[reject].cruise(), headers[reject].uid())][0] = True
         return rejects
     else:
         return []
@@ -134,7 +134,8 @@ def detectExcessiveSpeed(speeds, angles, index, maxSpeed):
     '''
 
     flag = speeds[index] > maxSpeed
-    if index < len(angles) - 1:
+
+    if index < len(angles) and index > 0:
         flag = flag or ( (speeds[index] > 0.8*maxSpeed) and (angles[index]>math.pi/2 or angles[index-1]>math.pi/2) )
 
     return flag

--- a/qctests/EN_track_check.py
+++ b/qctests/EN_track_check.py
@@ -205,7 +205,7 @@ def condition_a(headers, speeds, angles, index, maxSpeed):
             return 0
     elif index == len(headers)-1 and len(headers)>3:  # why not >=? seems to cause problems, investigate.
         impliedSpeed = trackSpeed(headers[-3], headers[-1])
-        if impliedSpeed < maxSpeed and (speeds[-2] > maxSpeed or angles[-2]>45./180.*math.pi):
+        if impliedSpeed < maxSpeed and (speeds[-2] > maxSpeed or angles[-3]>45./180.*math.pi):
             return index-1
         else:
             return index

--- a/qctests/EN_track_check.py
+++ b/qctests/EN_track_check.py
@@ -31,6 +31,10 @@ def test(p):
     cruise = p.cruise()
     uid = p.uid()
 
+    # don't bother if cruise == 0 or None
+    if cruise in [0, None]:
+        return np.zeros(1, dtype=bool);
+
     # The headers from an entire cruise must be analyzed all at once;
     # we'll write the results to the global data store, in a dictionary
     # with ntuple keys (cruise, uid), and values as single element
@@ -42,7 +46,7 @@ def test(p):
         return EN_track_results[(cruise, uid)]
 
     # some detector types cannot be assessed by this test; do not raise flag.
-    if p.probe_type in [None,0]:
+    if p.probe_type in [None]:
         return np.zeros(1, dtype=bool)
 
     # the first time this test is run, sort ds.threadProfiles into a cruise-keyed dictionary:

--- a/qctests/EN_track_check.py
+++ b/qctests/EN_track_check.py
@@ -338,9 +338,9 @@ def condition_h(headers, speeds, angles, index, maxSpeed):
         PT1 = geo.deltaTime(headers[index-2], headers[index-1]) / geo.deltaTime(headers[index-2], headers[index+1])
         PT2 = geo.deltaTime(headers[index-2], headers[index]) / geo.deltaTime(headers[index-2], headers[index+1])
 
-        if math.abs(PD1-PT1) > 0.1 + math.abs(PD2-PT2):
+        if abs(PD1-PT1) > 0.1 + abs(PD2-PT2):
             return index-1
-        if math.abs(PD2 - PT2) > 0.1 + math.abs(PD1 - PT1):
+        if abs(PD2 - PT2) > 0.1 + abs(PD1 - PT1):
             return index
 
     return -1

--- a/qctests/EN_track_check.py
+++ b/qctests/EN_track_check.py
@@ -84,6 +84,9 @@ def findOutlier(headers):
     maxShipSpeed = 15. # m/s
     maxBuoySpeed = 2. # m/s
 
+    if headers == []:
+        return []
+
     # determine speeds and angles for list of headers
     speeds, angles = calculateTraj(headers)
 
@@ -224,7 +227,9 @@ def condition_a(headers, speeds, angles, index, maxSpeed):
     assess condition (a) from the text
     '''
 
-    if index == 1: # note 'M' in the text seems to count from 1, not 0.
+    if index == 1 and len(headers) == 2:
+        return 0, 'a'
+    elif index == 1 and len(headers) > 2: # note 'M' in the text seems to count from 1, not 0.
         impliedSpeed = trackSpeed(headers[0], headers[2])
         if impliedSpeed < maxSpeed and (speeds[2]>maxSpeed or angles[2]>45./180.*math.pi):
             return 1, 'a'
@@ -243,7 +248,6 @@ def condition_b(headers, speeds, angles, index, maxSpeed):
     '''
     assess condition (b) from the text
     '''
-
     if speeds[index-1] > maxSpeed:
         return index-1, 'b'
     elif index < len(speeds) - 1 and speeds[index+1] > maxSpeed:
@@ -287,11 +291,13 @@ def condition_e(headers, speeds, angles, index, maxSpeed):
     assess condition (e) from the text
     '''
 
-    if None not in [angles[index-2], angles[index+1]] and angles[index-2] > 45./180.*math.pi and angles[index-2] > angles[index+1]:
-        return index-1, 'e'
+    if len(headers) > max(2, index+1):
 
-    if None not in [angles[index+1]] and angles[index+1] > 45./180.*math.pi:
-        return index, 'e'
+        if None not in [angles[index-2], angles[index+1]] and angles[index-2] > 45./180.*math.pi and angles[index-2] > angles[index+1]:
+            return index-1, 'e'
+
+        if None not in [angles[index+1]] and angles[index+1] > 45./180.*math.pi:
+            return index, 'e'
 
     return condition_f(headers, speeds, angles, index, maxSpeed)
 

--- a/qctests/EN_track_check.py
+++ b/qctests/EN_track_check.py
@@ -1,0 +1,362 @@
+""" 
+Implements the EN track check, described on pp 7 and 21 of
+http://www.metoffice.gov.uk/hadobs/en3/OQCpaper.pdf
+"""
+
+import numpy as np
+import data.ds as ds
+import util.main as main
+import util.geo as geo
+import copy
+import datetime
+import math
+
+# module constants
+DistRes = 20000. # meters
+TimeRes = 600. # seconds
+
+ds.EN_track_headers = {}
+ds.EN_track_results = {}
+
+def test(p):
+    """ 
+    Runs the quality control check on profile p and returns a numpy array 
+    of quality control decisions with False where the data value has 
+    passed the check and True where it failed. 
+    """
+
+    cruise = p.cruise()
+    uid = p.uid()
+
+    # The headers from an entire cruise must be analyzed all at once;
+    # we'll write the results to the global data store, in a dictionary
+    # with ntuple keys (cruise, uid), and values as single element
+    # numpy arrays, containing either a true or a false (per all the other
+    # qc return objects) 
+
+    # check if this profile has been examined already
+    if (cruise, uid) in ds.EN_track_results.keys():
+        return ds.EN_track_results[(cruise, uid)]
+
+    # some detector types cannot be assessed by this test; do not raise flag.
+    if p.probe_type in [None,0]:
+        return np.zeros(1, dtype=bool)
+
+    # the first time this test is run, sort ds.profiles into a cruise-keyed dictionary:
+    if ds.EN_track_headers == {}:
+        ds.EN_track_headers = main.sort_headers(ds.profiles)
+
+    # since we didn't find an answer already calculated,
+    # we still need to do the calculation for this cruise;
+    # all the relevant headers are sitting in the ds.EN_track_headers list.
+    headers = ds.EN_track_headers[cruise]
+
+    # start all as passing by default:
+    for i in range(len(headers)):
+        ds.EN_track_results[(headers[i].cruise(), headers[i].uid())] = np.zeros(1, dtype=bool)
+
+    # copy the list of headers;
+    # remove entries as they are flagged.
+    passedHeaders = copy.deepcopy(headers)
+    rejects = findOutlier(passedHeaders)
+    while rejects != []:
+        passedIndex = [x for x in range(len(passedHeaders)) if x not in rejects ]
+        passedHeaders = [passedHeaders[index] for index in passedIndex ]
+        rejects = findOutlier(passedHeaders)
+
+    # if more than half got rejected, reject everyone
+    if len(passedHeaders) < len(headers) / 2:
+        for i in range(len(headers)):
+            ds.EN_track_results[(headers[i].cruise(), headers[i].uid())][0] = True        
+
+    return ds.EN_track_results[(cruise, uid)]
+
+def findOutlier(headers):
+    '''
+    given a list of <headers>, find the fastest one;
+    if it's too fast, reject it or the one before it, return a list of rejected indices;
+    once the fastest is within limits, return [].
+    '''
+
+    maxShipSpeed = 15. # m/s
+    maxBuoySpeed = 2. # m/s
+
+    # determine speeds and angles for list of headers
+    speeds, angles = calculateTraj(headers)
+
+    # decide if something needs to be flagged
+    maxSpeed = maxShipSpeed
+    if isBuoy(headers[0]):
+        maxSpeed = maxBuoySpeed
+    iMax = speeds.index(max(speeds))
+    flag = detectExcessiveSpeed(speeds, angles, iMax, maxSpeed)
+
+    # decide which profile to reject, flag it, and return a list of indices rejected at this step.
+    if flag:
+        rejects = chooseReject(headers, speeds, angles, iMax, maxSpeed)
+        for reject in rejects:
+            ds.EN_track_results[(headers[reject].cruise(), headers[reject].uid())][0] = True
+        return rejects
+    else:
+        return []
+
+def calculateTraj(headers):
+    '''
+    return a list of speeds and a list of angles describing the trajectory of the track described
+    by the time-ordered list of <headers>.
+    '''
+
+    speeds = [-1]
+    angles = [-1]
+
+    # Find speed and angle for all profiles remaining in the list
+    for i in range(1, len(headers)):
+
+        speeds.append(None)
+        angles.append(None)
+
+        speeds[i] = trackSpeed(headers[i-1], headers[i])
+        if i < len(headers)-1: # can't do angle on last point 
+            angles[i] = geo.haversineAngle(headers[i-1], headers[i], headers[i+1])
+
+    return speeds, angles
+
+def isBuoy(header):
+    '''
+    decide if header belongs to a buoy-based measurement
+    '''
+
+    return header.probe_type in [4,7,9,10,11,12,13,15]
+
+def detectExcessiveSpeed(speeds, angles, index, maxSpeed):
+    '''
+    decide if there was an excessive speed at <index> in the lists <speeds> and <angles>
+    '''
+
+    flag = speeds[index] > maxSpeed
+    if index < len(angles) - 1:
+        flag = flag or ( (speeds[index] > 0.8*maxSpeed) and (angles[index]>math.pi/2 or angles[index-1]>math.pi/2) )
+
+    return flag
+
+
+def trackSpeed(prevHeader, header):
+    '''
+    computes the speed, including rounding tolerance from the reference,
+    for the track at <header>.
+    return None if some necessary data is missing
+    '''
+
+    # check that all required data is present:
+    if None in [header.latitude(), header.longitude(), prevHeader.latitude(), prevHeader.longitude()]:
+        return None
+    if None in [header.year(), header.month(), header.day(), header.time(), prevHeader.year(), prevHeader.month(), prevHeader.day(), prevHeader.time()]:
+        return None
+
+    dist = geo.haversineDistance(prevHeader, header)
+    DTime = geo.deltaTime(prevHeader, header)
+    speed = (dist - DistRes) / max(DTime, TimeRes)
+
+    return speed
+
+def chooseReject(headers, speeds, angles, index, maxSpeed):
+    '''
+    decide which profile to reject, headers[index] or headers[index-1], or both,
+    and return a list of indices to reject.
+    '''
+
+    # chain of tests breaks when a reject is found:
+    reject = condition_a(headers, speeds, angles, index, maxSpeed)
+
+    # condition i needs to run at the end of the chain in all cases:
+    # if no decision, reject both:
+    if reject == -1:
+        reject = [index-1, index]
+    # if excessive speed is created by removing the flag, reject both instead 
+    # can't create new excessive speed by removing last profile.
+    elif reject < len(headers)-1: 
+        newHeaders = copy.deepcopy(headers)
+        del newHeaders[reject]
+        newSpeeds, newAngles = calculateTraj(newHeaders)
+        flag = detectExcessiveSpeed(newSpeeds, newAngles, reject, maxSpeed)
+        if flag:
+            reject = [index-1, index]
+        else:
+            reject = [reject]
+    else:
+        reject = [reject]
+
+    return reject
+
+def condition_a(headers, speeds, angles, index, maxSpeed):
+    '''
+    assess condition (a) from the text
+    todo: the analogy refered to in the text for the last element isn't obvious.
+    '''
+
+    if index == 1: # note 'M' in the text seems to count from 1, not 0.
+        impliedSpeed = trackSpeed(headers[0], headers[2])
+        if impliedSpeed < maxSpeed and (speeds[2]>maxSpeed or angles[2]>45./180.*math.pi):
+            return 1
+        else:
+            return 0
+    elif index == len(headers)-1 and len(headers)>3:  # why not >=? seems to cause problems, investigate.
+        impliedSpeed = trackSpeed(headers[-3], headers[-1])
+        if impliedSpeed < maxSpeed and (speeds[-2] > maxSpeed or angles[-2]>45./180.*math.pi):
+            return index-1
+        else:
+            return index
+    else:
+        return condition_b(headers, speeds, angles, index, maxSpeed)
+
+def condition_b(headers, speeds, angles, index, maxSpeed):
+    '''
+    assess condition (b) from the text
+    '''
+
+    if speeds[index-1] > maxSpeed:
+        return index-1
+    elif index < len(speeds) - 1 and speeds[index+1] > maxSpeed:
+        return index
+
+    return condition_c(headers, speeds, angles, index, maxSpeed)
+
+def condition_c(headers, speeds, angles, index, maxSpeed):
+    '''
+    assess condition (c) from the text
+    '''
+
+    if index < len(headers)-1 and index > 0:
+        impliedSpeed = trackSpeed(headers[index-1], headers[index+1])
+        if impliedSpeed > maxSpeed:
+            return index-1
+
+    if index > 1:
+        impliedSpeed = trackSpeed(headers[index-2], headers[index])
+        if impliedSpeed > maxSpeed:
+            return index
+
+    return condition_d(headers, speeds, angles, index, maxSpeed)
+
+
+def condition_d(headers, speeds, angles, index, maxSpeed):
+    '''
+    assess condition (d) from the text
+    '''
+
+    if None not in [angles[index-1], angles[index]] and angles[index-1] > 45./180.*math.pi + angles[index]:
+        return index-1
+
+    if None not in [angles[index-1], angles[index]] and angles[index] > 45./180.*math.pi + angles[index-1]:
+        return index
+
+    return condition_e(headers, speeds, angles, index, maxSpeed)
+
+def condition_e(headers, speeds, angles, index, maxSpeed):
+    '''
+    assess condition (e) from the text
+    '''
+
+    if None not in [angles[index-2], angles[index+1]] and angles[index-2] > 45./180.*math.pi and angles[index-2] > angles[index+1]:
+        return index-1
+
+    if None not in [angles[index+1]] and angles[index+1] > 45./180.*math.pi:
+        return index    
+
+    return condition_f(headers, speeds, angles, index, maxSpeed)
+
+def condition_f(headers, speeds, angles, index, maxSpeed):
+    '''
+    assess condition (f) from the text
+    '''
+
+    if index>0 and index < len(speeds)-1:
+
+        # determine mean speed, neglecting missing data, intervals less than 1h, and speeds over maxspeed:
+        meanSpeed = 0
+        speedCount = 0
+        for iSpeed, speed in enumerate(speeds):
+            if speed == None:
+                continue
+            elif iSpeed > 0 and geo.deltaTime(headers[iSpeed-1], headers[iSpeed]) < 3600.:
+                continue
+            else:
+                meanSpeed += speed
+                speedCount += 1
+
+        if speedCount > 0:
+            meanSpeed = meanSpeed / speedCount
+
+        if None not in [speeds[index-1], speeds[index+1]] and speeds[index-1] < min([speeds[index+1], 0.5*meanSpeed]):
+            return index-1
+
+        if None not in [speeds[index-1], speeds[index+1]] and speeds[index+1] < min([speeds[index-1], 0.5*meanSpeed]):
+            return index
+
+    return condition_g(headers, speeds, angles, index, maxSpeed)
+
+def condition_g(headers, speeds, angles, index, maxSpeed):
+    '''
+    assess condition (g) from the text
+    '''
+
+    if index > 1 and index < len(headers) - 1:
+
+        dist1 = geo.haversineDistance(headers[index], headers[index-2]) + geo.haversineDistance(headers[index + 1], headers[index])
+        dist2 = geo.haversineDistance(headers[index-1], headers[index-2]) + geo.haversineDistance(headers[index + 1], headers[index-1])
+
+        distTol = geo.haversineDistance(headers[index-1], headers[index-2])
+        distTol += geo.haversineDistance(headers[index], headers[index-1])
+        distTol += geo.haversineDistance(headers[index+1], headers[index])
+        distTol = max(DistRes, 0.1*distTol)
+
+        if dist1 < dist2 - distTol:
+            return index-1
+
+        if dist2 < dist1 - distTol:
+            return index
+
+    return condition_h(headers, speeds, angles, index, maxSpeed)
+
+def condition_h(headers, speeds, angles, index, maxSpeed):
+    '''
+    assess condition (h) from the text
+    typeo in text, implementation incomplete
+    '''
+
+    if index > 1 and index < len(headers) - 1:
+
+        dist1 = geo.haversineDistance(headers[index], headers[index-2]) + geo.haversineDistance(headers[index + 1], headers[index])
+        dist2 = geo.haversineDistance(headers[index-1], headers[index-2]) + geo.haversineDistance(headers[index + 1], headers[index-1])
+
+        PD1 = geo.haversineDistance(headers[index-1], headers[index-2]) / dist2
+        PD2 = geo.haversineDistance(headers[index], headers[index-2]) / dist1
+
+        PT1 = geo.deltaTime(headers[index-2], headers[index-1]) / geo.deltaTime(headers[index-2], headers[index+1])
+        PT2 = geo.deltaTime(headers[index-2], headers[index]) / geo.deltaTime(headers[index-2], headers[index+1])
+
+        if math.abs(PD1-PT1) > 0.1 + math.abs(PD2-PT2):
+            return index-1
+        if math.abs(PD2 - PT2) > 0.1 + math.abs(PD1 - PT1):
+            return index
+
+    return -1
+
+def checkOrder(profiles):
+    '''
+    check that a list of profiles is properly time ordered
+    '''
+
+    dates = []
+    for pro in profiles:
+        if pro.time() is not None:
+            hour, minute, second = geo.parseTime(pro.time())
+        else:
+            hour = 0
+            minute = 0
+            second = 0
+        date = datetime.datetime(year=pro.year(), month=pro.month(), day=pro.day(), hour=hour, minute=minute, second=second )
+        dates.append(date)
+
+    for i in range(len(dates)-1):
+        assert dates[i] <= dates [i+1], 'dates out of order %s %s' % (dates[i], dates[i+1])

--- a/qctests/EN_track_check.py
+++ b/qctests/EN_track_check.py
@@ -97,6 +97,7 @@ def findOutlier(headers):
     # decide which profile to reject, flag it, and return a list of indices rejected at this step.
     if flag:
         rejects = chooseReject(headers, speeds, angles, iMax, maxSpeed)
+
         for reject in rejects:
             EN_track_results[(headers[reject].cruise(), headers[reject].uid())][0] = True
         return rejects

--- a/qctests/EN_track_check.py
+++ b/qctests/EN_track_check.py
@@ -142,8 +142,8 @@ def calculateTraj(headers):
     by the time-ordered list of <headers>.
     '''
 
-    speeds = [-1]
-    angles = [-1]
+    speeds = [None]
+    angles = [None]
 
     # Find speed and angle for all profiles remaining in the list
     for i in range(1, len(headers)):
@@ -171,7 +171,7 @@ def detectExcessiveSpeed(speeds, angles, index, maxSpeed):
 
     flag = speeds[index] > maxSpeed
 
-    if index < len(angles) and index > 0:
+    if index > 0:
         flag = flag or ( (speeds[index] > 0.8*maxSpeed) and (angles[index]>math.pi/2 or angles[index-1]>math.pi/2) )
 
     return flag

--- a/tests/EN_track_validation.py
+++ b/tests/EN_track_validation.py
@@ -112,7 +112,7 @@ class TestClass():
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
 
-        flag = qctests.EN_track_check.condition_a(profiles, speeds, angles, 1, 15)
+        flag = qctests.EN_track_check.condition_a(profiles, speeds, angles, 1, 15)[0]
 
         assert flag == 1, 'should have rejected the second profile due to high speed from second to third profile.'
 
@@ -129,7 +129,7 @@ class TestClass():
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
 
-        flag = qctests.EN_track_check.condition_a(profiles, speeds, angles, 1, 15)
+        flag = qctests.EN_track_check.condition_a(profiles, speeds, angles, 1, 15)[0]
 
         assert flag == 1, 'should have rejected the second profile due to high angle at third profile.'
 
@@ -145,7 +145,7 @@ class TestClass():
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
 
-        flag = qctests.EN_track_check.condition_a(profiles, speeds, angles, 1, 15)
+        flag = qctests.EN_track_check.condition_a(profiles, speeds, angles, 1, 15)[0]
 
         assert flag == 0, 'should have rejected the first profile due to high speed from first to third.'
 
@@ -161,7 +161,7 @@ class TestClass():
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
 
-        flag = qctests.EN_track_check.condition_a(profiles, speeds, angles, 1, 15)
+        flag = qctests.EN_track_check.condition_a(profiles, speeds, angles, 1, 15)[0]
 
         assert flag == 0, 'should have rejected the first profile since the second seems ok.'
 
@@ -180,7 +180,7 @@ class TestClass():
         
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
 
-        flag = qctests.EN_track_check.condition_a(profiles, speeds, angles, 5, 15)
+        flag = qctests.EN_track_check.condition_a(profiles, speeds, angles, 5, 15)[0]
         
         assert flag == 4, 'should have rejected the second to last profile due to high speed from third to last to second to last profile.'
 
@@ -199,7 +199,7 @@ class TestClass():
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
 
-        flag = qctests.EN_track_check.condition_a(profiles, speeds, angles, 5, 15)
+        flag = qctests.EN_track_check.condition_a(profiles, speeds, angles, 5, 15)[0]
 
         assert flag == 4, 'should have rejected the second to last profile due to high angle at third to final profile.'
 
@@ -218,7 +218,7 @@ class TestClass():
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
 
-        flag = qctests.EN_track_check.condition_a(profiles, speeds, angles, 5, 15)
+        flag = qctests.EN_track_check.condition_a(profiles, speeds, angles, 5, 15)[0]
 
         assert flag == 5, 'should have rejected the last profile since the second to last seems ok.'
 
@@ -237,7 +237,7 @@ class TestClass():
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
 
-        flag = qctests.EN_track_check.condition_b(profiles, speeds, angles, 4, 15)
+        flag = qctests.EN_track_check.condition_b(profiles, speeds, angles, 4, 15)[0]
 
         assert flag == 3, 'speed 4 too fast, speed 3 too fast -> should reject 3'
 
@@ -251,7 +251,7 @@ class TestClass():
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
 
-        flag = qctests.EN_track_check.condition_b(profiles, speeds, angles, 4, 15)
+        flag = qctests.EN_track_check.condition_b(profiles, speeds, angles, 4, 15)[0]
 
         assert flag == 4, 'speed 4 too fast, speed 5 too fast -> should reject 4'
 
@@ -270,7 +270,7 @@ class TestClass():
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
         
-        flag = qctests.EN_track_check.condition_c(profiles, speeds, angles, 4, 15)
+        flag = qctests.EN_track_check.condition_c(profiles, speeds, angles, 4, 15)[0]
 
         assert flag == 3, 'speed 4 too fast, speed 3 to 5 too fast -> should reject 3'
 
@@ -284,7 +284,7 @@ class TestClass():
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
 
-        flag = qctests.EN_track_check.condition_c(profiles, speeds, angles, 4, 15)
+        flag = qctests.EN_track_check.condition_c(profiles, speeds, angles, 4, 15)[0]
 
         assert flag == 4, 'speed 4 too fast, speed 2 to 4 too fast -> should reject 4'
 
@@ -303,7 +303,7 @@ class TestClass():
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
         
-        flag = qctests.EN_track_check.condition_d(profiles, speeds, angles, 4, 15)
+        flag = qctests.EN_track_check.condition_d(profiles, speeds, angles, 4, 15)[0]
 
         assert flag == 3, 'speed 4 too fast, angle at 3 too large -> should reject 3'
 
@@ -317,7 +317,7 @@ class TestClass():
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
     
-        flag = qctests.EN_track_check.condition_d(profiles, speeds, angles, 4, 15)
+        flag = qctests.EN_track_check.condition_d(profiles, speeds, angles, 4, 15)[0]
         
         assert flag == 4, 'speed 4 too fast, angle at 4 too large -> should reject 4'
 
@@ -337,7 +337,7 @@ class TestClass():
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
     
-        flag = qctests.EN_track_check.condition_e(profiles, speeds, angles, 4, 15)
+        flag = qctests.EN_track_check.condition_e(profiles, speeds, angles, 4, 15)[0]
 
         assert flag == 3, 'speed 4 too fast, angle at 2 too large -> should reject 3'
 
@@ -352,7 +352,7 @@ class TestClass():
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
         
-        flag = qctests.EN_track_check.condition_e(profiles, speeds, angles, 4, 15)
+        flag = qctests.EN_track_check.condition_e(profiles, speeds, angles, 4, 15)[0]
         
         assert flag == 4, 'speed 4 too fast, angle at 5 too large -> should reject 4'
 
@@ -371,7 +371,7 @@ class TestClass():
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
     
-        flag = qctests.EN_track_check.condition_f(profiles, speeds, angles, 4, 15)
+        flag = qctests.EN_track_check.condition_f(profiles, speeds, angles, 4, 15)[0]
 
         assert flag == 3, 'speed 4 too fast, speed 3 very small -> should reject 3'
 
@@ -385,7 +385,7 @@ class TestClass():
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
         
-        flag = qctests.EN_track_check.condition_f(profiles, speeds, angles, 4, 15)
+        flag = qctests.EN_track_check.condition_f(profiles, speeds, angles, 4, 15)[0]
         
         assert flag == 4, 'speed 4 too fast, speed 5 very small -> should reject 4'
 
@@ -404,7 +404,7 @@ class TestClass():
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
     
-        flag = qctests.EN_track_check.condition_g(profiles, speeds, angles, 4, 15)
+        flag = qctests.EN_track_check.condition_g(profiles, speeds, angles, 4, 15)[0]
 
         assert flag == 3, 'positions 2, 4 and 5 all closely clustered but 3 far away -> should reject 3'
 
@@ -418,7 +418,7 @@ class TestClass():
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
         
-        flag = qctests.EN_track_check.condition_g(profiles, speeds, angles, 4, 15)
+        flag = qctests.EN_track_check.condition_g(profiles, speeds, angles, 4, 15)[0]
         
         assert flag == 4, 'positions 2, 3 and 5 closely clustered but 4 far away -> should reject 4'
 
@@ -437,7 +437,7 @@ class TestClass():
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
     
-        flag = qctests.EN_track_check.condition_h(profiles, speeds, angles, 4, 15)
+        flag = qctests.EN_track_check.condition_h(profiles, speeds, angles, 4, 15)[0]
 
         assert flag == 3, 'nonsmooth behavior at profile 3 -> should reject 3'
 
@@ -451,7 +451,7 @@ class TestClass():
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
         
-        flag = qctests.EN_track_check.condition_h(profiles, speeds, angles, 4, 15)
+        flag = qctests.EN_track_check.condition_h(profiles, speeds, angles, 4, 15)[0]
         
         assert flag == 4, 'nonsmooth behavior at 4 -> should reject 4'
 
@@ -578,10 +578,9 @@ class TestClass():
         ds.threadProfiles = []
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 30, 5], cruise=1000, uid=1))
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 30, 6], cruise=1000, uid=2))
-
-        #first pass: reject on (c)
+        #first pass: reject profile[2] on (c)
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 7], cruise=1000, uid=3))
-       
+        #inital speed check: flag profile[3]
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 8], cruise=1000, uid=4))
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18.5, longitude=90, date=[1999, 12, 31, 9], cruise=1000, uid=5))
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19, longitude=90, date=[1999, 12, 31, 10], cruise=1000, uid=6))
@@ -595,6 +594,10 @@ class TestClass():
 
         assert numpy.array_equal(truth, qctests.EN_track_check.EN_track_results), 'condition (c) reject'
 
+        speeds, angles = qctests.EN_track_check.calculateTraj(ds.threadProfiles)
+        flag = qctests.EN_track_check.condition_a(ds.threadProfiles, speeds, angles, 3, 15)[1]
+        assert flag == 'c', 'Correct profile flagged, but not by the expected step.'
+
     def condition_d_integration_test(self):
         '''
         track passes until condition d
@@ -604,10 +607,9 @@ class TestClass():
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 30, 5], cruise=1000, uid=1))
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 30, 6], cruise=1000, uid=2))
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 7], cruise=1000, uid=3))
-
-        #first pass: reject on (d)
+        #initial speed check: flag profile[3]
+        #first pass: reject profile[3] on (d)
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 8], cruise=1000, uid=4))
-
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17.5, longitude=90, date=[1999, 12, 31, 9], cruise=1000, uid=5))
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 10], cruise=1000, uid=6))
 
@@ -620,6 +622,10 @@ class TestClass():
 
         assert numpy.array_equal(truth, qctests.EN_track_check.EN_track_results), 'condition (d) reject'
 
+        speeds, angles = qctests.EN_track_check.calculateTraj(ds.threadProfiles)
+        flag = qctests.EN_track_check.condition_a(ds.threadProfiles, speeds, angles, 3, 15)[1]
+        assert flag == 'd', 'Correct profile flagged, but not by the expected step.'
+
     def condition_e_integration_test(self):
         '''
         track passes until condition e
@@ -629,10 +635,9 @@ class TestClass():
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 30, 5], cruise=1000, uid=1))
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 30, 6], cruise=1000, uid=2))
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 30, 7], cruise=1000, uid=3))
-
-        #first pass: reject on (e)
+        #first pass: reject profile[3] on (e)
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 31, 8], cruise=1000, uid=4))
-       
+        #initial speed check: flag profile[4]
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=15.5, longitude=90, date=[1999, 12, 31, 9], cruise=1000, uid=5))
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=15, longitude=90, date=[2000, 01, 01, 10], cruise=1000, uid=6))
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=14.5, longitude=90, date=[2000, 01, 01, 11], cruise=1000, uid=7))
@@ -646,6 +651,10 @@ class TestClass():
 
         assert numpy.array_equal(truth, qctests.EN_track_check.EN_track_results), 'condition (e) reject'
 
+        speeds, angles = qctests.EN_track_check.calculateTraj(ds.threadProfiles)
+        flag = qctests.EN_track_check.condition_a(ds.threadProfiles, speeds, angles, 4, 15)[1]
+        assert flag == 'e', 'Correct profile flagged, but not by the expected step.'
+
     def condition_f_integration_test(self):
         '''
         track passes until condition f
@@ -653,13 +662,12 @@ class TestClass():
 
         ds.threadProfiles = []
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 1], cruise=1000, uid=1))
-        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 31, 2], cruise=1000, uid=2))
-
-        #first pass: reject on (f)
-        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 7], cruise=1000, uid=3))
-        
-        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 8], cruise=1000, uid=4))
-        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18.5, longitude=90, date=[1999, 12, 31, 9], cruise=1000, uid=5))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 31, 3], cruise=1000, uid=2))
+        #first pass: reject profile[2] on (f)
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 8], cruise=1000, uid=3))
+        #initial speed check: flag profile[3]
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 9], cruise=1000, uid=4))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18.5, longitude=90, date=[1999, 12, 31, 11], cruise=1000, uid=5))
 
         qctests.EN_track_check.test(ds.threadProfiles[4])
 
@@ -670,6 +678,37 @@ class TestClass():
 
         assert numpy.array_equal(truth, qctests.EN_track_check.EN_track_results), 'condition (f) reject'
 
+        speeds, angles = qctests.EN_track_check.calculateTraj(ds.threadProfiles)
+        flag = qctests.EN_track_check.condition_a(ds.threadProfiles, speeds, angles, 3, 15)[1]
+        print flag
+        assert flag == 'f', 'Correct profile flagged, but not by the expected step.'
+
+    def condition_g_integration_test(self):
+        '''
+        track passes until condition g
+        '''
+
+        ds.threadProfiles = []
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1998, 12, 31, 1], cruise=1000, uid=1))
+        #first pass: reject profile[1] on (g)
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=89, date=[1999, 12, 31, 1], cruise=1000, uid=2))
+        #inital speed check: flag profile[2]
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 2], cruise=1000, uid=3))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20, longitude=90, date=[2000, 12, 31, 3], cruise=1000, uid=4))
+
+        qctests.EN_track_check.test(ds.threadProfiles[3])
+
+        truth = {}
+        for i in range(1,5):
+            truth[(1000, i)] = numpy.zeros(1, dtype=bool)
+        truth[(1000, 2)] = numpy.ones(1, dtype=bool)
+
+        assert numpy.array_equal(truth, qctests.EN_track_check.EN_track_results), 'condition (g) reject'
+
+        speeds, angles = qctests.EN_track_check.calculateTraj(ds.threadProfiles)
+        flag = qctests.EN_track_check.condition_a(ds.threadProfiles, speeds, angles, 2, 15)[1]
+        assert flag == 'g', 'Correct profile flagged, but not by the expected step.'
+
     def condition_h_integration_test(self):
         '''
         track passes until condition h
@@ -679,10 +718,9 @@ class TestClass():
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 9], cruise=1000, uid=1))
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 12], cruise=1000, uid=2))
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 15], cruise=1000, uid=3))
-
-        #first pass: reject on (h)
+        #initial speed check: flag profile [3]
+        #first pass: reject profile[3] on (h)
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19, longitude=90, date=[1999, 12, 31, 16], cruise=1000, uid=4))
-        
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20, longitude=90, date=[1999, 12, 31, 20], cruise=1000, uid=5))
         #PD1: 1/3
         #PD2: 2/3
@@ -698,6 +736,8 @@ class TestClass():
 
         assert numpy.array_equal(truth, qctests.EN_track_check.EN_track_results), 'condition (h) reject'
 
-
+        speeds, angles = qctests.EN_track_check.calculateTraj(ds.threadProfiles)
+        flag = qctests.EN_track_check.condition_a(ds.threadProfiles, speeds, angles, 3, 15)[1]
+        assert flag == 'h', 'Correct profile flagged, but not by the expected step.'
 
 

--- a/tests/EN_track_validation.py
+++ b/tests/EN_track_validation.py
@@ -1,0 +1,92 @@
+import util.main as main
+import os, math
+from wodpy import wod
+import numpy, pandas
+import util.testingProfile
+import qctests.EN_track_check
+import util.geo
+
+class TestClass():
+    # def setUp(self):
+
+    distRes = 20000. #meters
+    timeRes = 600.   #seconds
+
+    #     # #create an incorrectly formatted list of input files
+    #     # file = open("notalist.json", "w")
+    #     # file.write('{"not": "alist"}')
+    #     # file.close()
+
+    #     # #create a list of input files that does not exist
+    #     # file = open("dne.json", "w")
+    #     # file.write('["data/doesnotexist.dat"]')
+    #     # file.close()
+
+    #     # #create an artificial profile to trigger the temperature flag
+    #     # #sets first temperature to 99.9; otherwise identical to data/example.dat
+    #     # file = open("temp.dat", "w")
+    #     # file.write('C41303567064US5112031934 8 744210374426193562-17227140 6110101201013011182205814\n')
+    #     # file.write('01118220291601118220291901024721 8STOCS85A3 41032151032165-500632175-50023218273\n')
+    #     # file.write('18117709500110134401427143303931722076210220602291107291110329977020133023846181\n')
+    #     # file.write('24421800132207614110217330103192220521322011216442103723077095001101818115508527\n')
+    #     # file.write('20012110000133312500021011060022022068002272214830228442684000230770421200000191\n')
+    #     # file.write('15507911800121100001333125000151105002103302270022022068002274411816302284426840\n')
+    #     # file.write('00230770426500000191155069459001211000013331250001511050021033011300220220680022\n')
+    #     # file.write('73319043022844268400023077042620000019116601596680012110000133312500021022016002\n')
+    #     # file.write('17110100220220680022733112830228442684000230770435700000181155088803001211000013\n')
+    #     # file.write('33125000210220160022022068002273311283022844268400023077042120000019115508880300\n')
+    #     # file.write('12110000133312500015110200210330535002202206800227441428030228442684000230770421\n')
+    #     # file.write('20000019115508880300121100001333125000152204300210220320022022068002273312563022\n')
+    #     # file.write('84426840002307704212000001911550853710012110000133312500015110200210220160022022\n')
+    #     # file.write('06800227331128302284426840002307704212000001100001319990044230900033267500222650\n')
+    #     # file.write('03312050033281000220100033289500442309000332670002227100331123003328100022025002\n')
+    #     # file.write('22900044231910033286200222900033115400332810002205000342-12300442324100332728003\n')
+    #     # file.write('32117003312560033280500                                                         \n')
+    #     # file.close()
+
+
+    #     # return
+
+    # def tearDown(self):
+
+    #     return
+
+    def trackSpeed_test(self):
+        '''
+        spot check on trackSpeed function
+        '''
+
+        first = util.testingProfile.fakeProfile([0], [0], latitude=0, longitude=90, date=[1999, 12, 31, 0])
+        last =  util.testingProfile.fakeProfile([0], [0], latitude=1, longitude=90, date=[1999, 12, 31, 1])
+
+        trueDistance = util.geo.haversineDistance(first, last)
+        trueSpeed = (trueDistance - self.distRes)/max(3600., self.timeRes)
+
+        assert qctests.EN_track_check.trackSpeed(first, last) == trueSpeed
+
+    def detectExcessiveSpeed_test(self):
+        '''
+        spot checks on excessive speed flag
+        '''
+
+        speeds = [10,9,9,20]
+        angles = [math.pi, math.pi/4, math.pi/4]
+
+        assert qctests.EN_track_check.detectExcessiveSpeed(speeds, angles, 0, 2), 'failed to flag a speed in excess of max speed'
+        assert qctests.EN_track_check.detectExcessiveSpeed(speeds, angles, 1, 10), 'failed to flag moderate speed at high angle'
+        assert not qctests.EN_track_check.detectExcessiveSpeed(speeds, angles, 2, 10), 'flagged a moderate speed at small angle'
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/tests/EN_track_validation.py
+++ b/tests/EN_track_validation.py
@@ -263,9 +263,9 @@ class TestClass():
         profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18.5, longitude=90, date=[1999, 12, 31, 10]))
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
-        print speeds
+
         flag = qctests.EN_track_check.condition_c(profiles, speeds, angles, 4, 15)
-        print flag
+
         assert flag == 4, 'speed 4 too fast, speed 2 to 4 too fast -> should reject 4'
 
     def condition_d_test(self):
@@ -600,7 +600,31 @@ class TestClass():
 
         assert numpy.array_equal(truth, qctests.EN_track_check.EN_track_results), 'condition (d) reject'
 
+    def condition_e_integration_test(self):
+        '''
+        track passes until condition e
+        '''
 
+        ds.threadProfiles = []
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 30, 5], cruise=1000, uid=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 30, 6], cruise=1000, uid=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 30, 7], cruise=1000, uid=3))
+
+        #first pass: reject on (e)
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 31, 8], cruise=1000, uid=4))
+       
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=15.5, longitude=90, date=[1999, 12, 31, 9], cruise=1000, uid=5))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=15, longitude=90, date=[2000, 01, 01, 10], cruise=1000, uid=6))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=14.5, longitude=90, date=[2000, 01, 01, 11], cruise=1000, uid=7))
+
+        qctests.EN_track_check.test(ds.threadProfiles[5])
+
+        truth = {}
+        for i in range(1,8):
+            truth[(1000, i)] = numpy.zeros(1, dtype=bool)
+        truth[(1000, 4)] = numpy.ones(1, dtype=bool)
+
+        assert numpy.array_equal(truth, qctests.EN_track_check.EN_track_results), 'condition (e) reject'
 
 
 

--- a/tests/EN_track_validation.py
+++ b/tests/EN_track_validation.py
@@ -96,6 +96,22 @@ class TestClass():
 
         assert flag == 1, 'should have rejected the second profile due to high angle at third profile.'
 
+    def condition_a_speed2_test(self):
+        '''
+        condition a rejects the first profile if the speed from 1->3 is too large
+        '''
+
+        profiles = []
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=0, longitude=90, date=[1999, 12, 31, 0]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=0.5, longitude=90, date=[1999, 12, 31, 1]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=2, longitude=90, date=[1999, 12, 31, 2]))
+
+        speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
+
+        flag = qctests.EN_track_check.condition_a(profiles, speeds, angles, 1, 15)
+
+        assert flag == 0, 'should have rejected the first profile due to high speed from first to third.'
+
     def condition_a_nominal_test(self):
         '''
         condition a rejects the first profile if the second passes muster
@@ -119,17 +135,17 @@ class TestClass():
 
         profiles = []
         profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 5]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 6]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 7]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19, longitude=90, date=[1999, 12, 31, 8]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19.99, longitude=90, date=[1999, 12, 31, 9]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20, longitude=90, date=[1999, 12, 31, 10]))
-
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 31, 6]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 7]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18.5, longitude=90, date=[1999, 12, 31, 8]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19.49, longitude=90, date=[1999, 12, 31, 9]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19.5, longitude=90, date=[1999, 12, 31, 10]))
+        
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
 
         flag = qctests.EN_track_check.condition_a(profiles, speeds, angles, 5, 15)
-
-        assert flag == 4, 'should have rejected the second to last profile due to high speed from second to last to final profile.'
+        
+        assert flag == 4, 'should have rejected the second to last profile due to high speed from third to last to second to last profile.'
 
     def condition_a_angle_end_test(self):
         '''
@@ -138,17 +154,17 @@ class TestClass():
 
         profiles = []
         profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 5]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 6]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 7]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19, longitude=90, date=[1999, 12, 31, 8]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20, longitude=90, date=[1999, 12, 31, 9]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19, longitude=90, date=[1999, 12, 31, 10]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 31, 6]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 7]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17.5, longitude=90, date=[1999, 12, 31, 8]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 9]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 31, 10]))
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
 
         flag = qctests.EN_track_check.condition_a(profiles, speeds, angles, 5, 15)
 
-        assert flag == 4, 'should have rejected the second to last profile due to high angle at final profile.'
+        assert flag == 4, 'should have rejected the second to last profile due to high angle at third to final profile.'
 
     def condition_a_nominal_end_test(self):
         '''
@@ -157,11 +173,11 @@ class TestClass():
 
         profiles = []
         profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 5]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 6]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 7]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19, longitude=90, date=[1999, 12, 31, 8]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20, longitude=90, date=[1999, 12, 31, 9]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=21, longitude=90, date=[1999, 12, 31, 10]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 31, 6]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 7]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17.5, longitude=90, date=[1999, 12, 31, 8]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 9]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18.5, longitude=90, date=[1999, 12, 31, 10]))
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
 
@@ -176,11 +192,25 @@ class TestClass():
 
         profiles = []
         profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 5]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 6]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 7]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18.01, longitude=90, date=[1999, 12, 31, 8]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20, longitude=90, date=[1999, 12, 31, 9]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=22, longitude=90, date=[1999, 12, 31, 10]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 31, 6]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 7]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 8]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19, longitude=90, date=[1999, 12, 31, 9]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19.5, longitude=90, date=[1999, 12, 31, 10]))
+
+        speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
+
+        flag = qctests.EN_track_check.condition_b(profiles, speeds, angles, 4, 15)
+
+        assert flag == 3, 'speed 4 too fast, speed 3 too fast -> should reject 3'
+
+        profiles = []
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 5]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 31, 6]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 7]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17.5, longitude=90, date=[1999, 12, 31, 8]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18.5, longitude=90, date=[1999, 12, 31, 9]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19.5, longitude=90, date=[1999, 12, 31, 10]))
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
 
@@ -188,16 +218,136 @@ class TestClass():
 
         assert flag == 4, 'speed 4 too fast, speed 5 too fast -> should reject 4'
 
+    def condition_c_test(self):
+        '''
+        nominal behavior of condition c
+        '''
+
         profiles = []
         profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 5]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 6]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17.01, longitude=90, date=[1999, 12, 31, 7]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18.01, longitude=90, date=[1999, 12, 31, 8]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20, longitude=90, date=[1999, 12, 31, 9]))
-        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=21, longitude=90, date=[1999, 12, 31, 10]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 31, 6]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 7]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17.5, longitude=90, date=[1999, 12, 31, 8]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18.5, longitude=90, date=[1999, 12, 31, 9]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19.5, longitude=90, date=[1999, 12, 31, 10]))
 
         speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
+        
+        flag = qctests.EN_track_check.condition_c(profiles, speeds, angles, 4, 15)
 
-        flag = qctests.EN_track_check.condition_b(profiles, speeds, angles, 4, 15)
+        assert flag == 3, 'speed 4 too fast, speed 3 to 5 too fast -> should reject 3'
 
-        assert flag == 3, 'speed 4 too fast, speed 3 too fast -> should reject 3'
+        profiles = []
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=15.5, longitude=90, date=[1999, 12, 31, 5]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 6]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 31, 7]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17.5, longitude=90, date=[1999, 12, 31, 8]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18.5, longitude=90, date=[1999, 12, 31, 9]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18.5, longitude=90, date=[1999, 12, 31, 10]))
+
+        speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
+        print speeds
+        flag = qctests.EN_track_check.condition_c(profiles, speeds, angles, 4, 15)
+        print flag
+        assert flag == 4, 'speed 4 too fast, speed 2 to 4 too fast -> should reject 4'
+
+    def condition_d_test(self):
+        '''
+        nominal behavior of condition d
+        '''
+
+        profiles = []
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 5]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 31, 6]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 7]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17.5, longitude=90, date=[1999, 12, 31, 8]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 31, 9]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 10]))
+
+        speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
+        
+        flag = qctests.EN_track_check.condition_d(profiles, speeds, angles, 4, 15)
+
+        assert flag == 3, 'speed 4 too fast, angle at 3 too large -> should reject 3'
+
+        profiles = []
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 5]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 31, 6]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 7]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17.5, longitude=90, date=[1999, 12, 31, 8]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18.5, longitude=90, date=[1999, 12, 31, 9]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 10]))
+
+        speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
+    
+        flag = qctests.EN_track_check.condition_d(profiles, speeds, angles, 4, 15)
+        
+        assert flag == 4, 'speed 4 too fast, angle at 4 too large -> should reject 4'
+
+    def condition_e_test(self):
+        '''
+        nominal behavior of condition e
+        '''
+
+        profiles = []
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 5]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 31, 6]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 7]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 31, 8]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 9]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=15.5, longitude=90, date=[1999, 12, 31, 10]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=15, longitude=90, date=[1999, 12, 31, 11]))
+
+        speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
+    
+        flag = qctests.EN_track_check.condition_e(profiles, speeds, angles, 4, 15)
+
+        assert flag == 3, 'speed 4 too fast, angle at 2 too large -> should reject 3'
+
+        profiles = []
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 5]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 31, 6]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 7]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17.5, longitude=90, date=[1999, 12, 31, 8]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 9]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18.5, longitude=90, date=[1999, 12, 31, 10]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 11]))
+
+        speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
+        
+        flag = qctests.EN_track_check.condition_e(profiles, speeds, angles, 4, 15)
+        
+        assert flag == 4, 'speed 4 too fast, angle at 5 too large -> should reject 4'
+
+    def condition_f_test(self):
+        '''
+        nominal behavior of condition f
+        '''
+
+        profiles = []
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 5]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 31, 6]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 7]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 8]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 9]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18.5, longitude=90, date=[1999, 12, 31, 10]))
+
+        speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
+    
+        flag = qctests.EN_track_check.condition_f(profiles, speeds, angles, 4, 15)
+
+        assert flag == 3, 'speed 4 too fast, speed 3 very small -> should reject 3'
+
+        profiles = []
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 5]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 31, 6]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 7]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17.5, longitude=90, date=[1999, 12, 31, 8]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18.5, longitude=90, date=[1999, 12, 31, 9]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18.5, longitude=90, date=[1999, 12, 31, 10]))
+
+        speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
+        
+        flag = qctests.EN_track_check.condition_f(profiles, speeds, angles, 4, 15)
+        
+        assert flag == 4, 'speed 4 too fast, speed 5 very small -> should reject 4'

--- a/tests/EN_track_validation.py
+++ b/tests/EN_track_validation.py
@@ -790,7 +790,7 @@ class TestClass():
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=0, longitude=90, date=[1999, 12, 31, 0], cruise=1000, uid=1))
         ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=1, longitude=90, date=[1999, 12, 31, 0], cruise=1000, uid=2))
 
-        assert qctests.EN_track_check.test(ds.threadProfiles[0]) == False, 'Failed to handle identical times'
+        assert qctests.EN_track_check.test(ds.threadProfiles[0]) == True, 'Failed to handle identical times'
 
     def real_case_1_test(self):
         '''

--- a/tests/EN_track_validation.py
+++ b/tests/EN_track_validation.py
@@ -96,7 +96,108 @@ class TestClass():
 
         assert flag == 1, 'should have rejected the second profile due to high angle at third profile.'
 
+    def condition_a_nominal_test(self):
+        '''
+        condition a rejects the first profile if the second passes muster
+        '''
 
+        profiles = []
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=0, longitude=90, date=[1999, 12, 31, 0]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=0.5, longitude=90, date=[1999, 12, 31, 1]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=1, longitude=90, date=[1999, 12, 31, 2]))
 
+        speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
 
+        flag = qctests.EN_track_check.condition_a(profiles, speeds, angles, 1, 15)
 
+        assert flag == 0, 'should have rejected the first profile since the second seems ok.'
+
+    def condition_a_fast_end_test(self):
+        '''
+        speed test at end of profile
+        '''
+
+        profiles = []
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 5]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 6]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 7]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19, longitude=90, date=[1999, 12, 31, 8]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19.99, longitude=90, date=[1999, 12, 31, 9]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20, longitude=90, date=[1999, 12, 31, 10]))
+
+        speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
+
+        flag = qctests.EN_track_check.condition_a(profiles, speeds, angles, 5, 15)
+
+        assert flag == 4, 'should have rejected the second to last profile due to high speed from second to last to final profile.'
+
+    def condition_a_angle_end_test(self):
+        '''
+        angle test at end of profile
+        '''
+
+        profiles = []
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 5]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 6]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 7]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19, longitude=90, date=[1999, 12, 31, 8]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20, longitude=90, date=[1999, 12, 31, 9]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19, longitude=90, date=[1999, 12, 31, 10]))
+
+        speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
+
+        flag = qctests.EN_track_check.condition_a(profiles, speeds, angles, 5, 15)
+
+        assert flag == 4, 'should have rejected the second to last profile due to high angle at final profile.'
+
+    def condition_a_nominal_end_test(self):
+        '''
+        condition a rejects the last profile if the second to last passes muster
+        '''
+
+        profiles = []
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 5]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 6]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 7]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19, longitude=90, date=[1999, 12, 31, 8]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20, longitude=90, date=[1999, 12, 31, 9]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=21, longitude=90, date=[1999, 12, 31, 10]))
+
+        speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
+
+        flag = qctests.EN_track_check.condition_a(profiles, speeds, angles, 5, 15)
+
+        assert flag == 5, 'should have rejected the last profile since the second to last seems ok.'
+
+    def condition_b_test(self):
+        '''
+        nominal behavior of condition b
+        '''
+
+        profiles = []
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 5]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 6]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 7]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18.01, longitude=90, date=[1999, 12, 31, 8]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20, longitude=90, date=[1999, 12, 31, 9]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=22, longitude=90, date=[1999, 12, 31, 10]))
+
+        speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
+
+        flag = qctests.EN_track_check.condition_b(profiles, speeds, angles, 4, 15)
+
+        assert flag == 4, 'speed 4 too fast, speed 5 too fast -> should reject 4'
+
+        profiles = []
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 5]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 6]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17.01, longitude=90, date=[1999, 12, 31, 7]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18.01, longitude=90, date=[1999, 12, 31, 8]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20, longitude=90, date=[1999, 12, 31, 9]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=21, longitude=90, date=[1999, 12, 31, 10]))
+
+        speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
+
+        flag = qctests.EN_track_check.condition_b(profiles, speeds, angles, 4, 15)
+
+        assert flag == 3, 'speed 4 too fast, speed 3 too fast -> should reject 3'

--- a/tests/EN_track_validation.py
+++ b/tests/EN_track_validation.py
@@ -740,4 +740,272 @@ class TestClass():
         flag = qctests.EN_track_check.condition_a(ds.threadProfiles, speeds, angles, 3, 15)[1]
         assert flag == 'h', 'Correct profile flagged, but not by the expected step.'
 
+    def unusual_case_one_prof_test(self):
+        '''
+        spot check on handling of cruise with only one profile.
+        '''
+
+        # Some fake profiles
+        ds.threadProfiles = []
+
+        # Only one profile available.
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=0, longitude=90, date=[1999, 12, 31, 0], cruise=1000, uid=1))
+
+        assert qctests.EN_track_check.test(ds.threadProfiles[0]) == False, 'Failed to handle single profile'
+
+    def unusual_case_no_time_test(self):
+        '''
+        spot check on handling of profiles with incomplete data
+        '''
+
+        # Some fake profiles
+        ds.threadProfiles = []
+
+        # Time is missing.
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=0, longitude=90, date=[1999, 12, 31, 0], cruise=1000, uid=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=1, longitude=90, date=[1999, 12, 31, 1], cruise=1000, uid=2))
+        ds.threadProfiles[0].primary_header['Time'] = None
+
+        assert qctests.EN_track_check.test(ds.threadProfiles[0]) == False, 'Failed to handle missing time'
+
+    def unusual_case_identical_positions_test(self):
+        '''
+        spot check on handling of profiles with incomplete data
+        '''
+
+        # Some fake profiles
+        ds.threadProfiles = []
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=0, longitude=90, date=[1999, 12, 31, 0], cruise=1000, uid=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=0, longitude=90, date=[1999, 12, 31, 1], cruise=1000, uid=2))
+
+        assert qctests.EN_track_check.test(ds.threadProfiles[0]) == False, 'Failed to handle identical positions'
+
+    def unusual_case_identical_times_test(self):
+        '''
+        spot check on handling of profiles with incomplete data
+        '''
+
+        # Some fake profiles
+        ds.threadProfiles = []
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=0, longitude=90, date=[1999, 12, 31, 0], cruise=1000, uid=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=1, longitude=90, date=[1999, 12, 31, 0], cruise=1000, uid=2))
+
+        assert qctests.EN_track_check.test(ds.threadProfiles[0]) == False, 'Failed to handle identical times'
+
+    def real_case_1_test(self):
+        '''
+        A real instance of a series of a track with a failed track check reject.
+        '''
+        ds.threadProfiles = []
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=64.230000, longitude=-22.220000, date=[1925, 6, 3, 12.000000], cruise=45, uid=72, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=80.050000, longitude=12.000000, date=[1925, 6, 5, 12.000000], cruise=45, uid=112, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=80.470000, longitude=11.080000, date=[1925, 6, 6, 12.000000], cruise=45, uid=130, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=80.470000, longitude=12.000000, date=[1925, 6, 6, 12.000000], cruise=45, uid=134, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=80.130000, longitude=12.000000, date=[1925, 6, 6, 12.000000], cruise=45, uid=137, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=63.930000, longitude=-52.680000, date=[1925, 6, 9, 12.000000], cruise=45, uid=189, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=64.430000, longitude=-50.230000, date=[1925, 6, 15, 12.000000], cruise=45, uid=301, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=64.430000, longitude=-50.220000, date=[1925, 6, 15, 12.000000], cruise=45, uid=303, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=64.430000, longitude=-50.650000, date=[1925, 6, 16, 12.000000], cruise=45, uid=316, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=68.830000, longitude=-52.800000, date=[1925, 6, 22, 12.000000], cruise=45, uid=489, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=64.030000, longitude=-52.620000, date=[1925, 6, 28, 12.000000], cruise=45, uid=577, probe_type=7))
+        qc= [False, False, False, False, True, False, False, False, False, False, False]
+
+        tcqc = []
+        for p in ds.threadProfiles:
+            tcqc.append(qctests.EN_track_check.test(p)[0])
+
+        assert numpy.array_equal(qc, tcqc), 'QC results do not match those produced by EN system'
+
+    def real_case_2_test(self):
+        '''
+        A real instance of a series of a track with a failed track check reject.
+        '''
+        ds.threadProfiles = []
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=65.350000, longitude=-13.520000, date=[1925, 6, 11, 15.170000], cruise=843883, uid=222, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=65.300000, longitude=-13.000000, date=[1925, 6, 12, 11.830000], cruise=843883, uid=252, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=65.500000, longitude=-12.420000, date=[1925, 6, 12, 17.830000], cruise=843883, uid=256, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=65.820000, longitude=-12.430000, date=[1925, 6, 12, 23.330000], cruise=843883, uid=260, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=65.820000, longitude=-12.430000, date=[1925, 6, 12, 12.000000], cruise=843883, uid=261, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=65.500000, longitude=-12.420000, date=[1925, 6, 12, 12.000000], cruise=843883, uid=262, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=65.750000, longitude=-14.170000, date=[1925, 6, 13, 14.500000], cruise=843883, uid=272, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=66.270000, longitude=-14.370000, date=[1925, 6, 14, 2.750000], cruise=843883, uid=277, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=66.570000, longitude=-15.420000, date=[1925, 6, 14, 14.670000], cruise=843883, uid=279, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=66.600000, longitude=-16.450000, date=[1925, 6, 14, 18.500000], cruise=843883, uid=280, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=66.320000, longitude=-16.670000, date=[1925, 6, 15, 11.500000], cruise=843883, uid=289, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=66.020000, longitude=-17.400000, date=[1925, 6, 15, 18.500000], cruise=843883, uid=297, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=66.220000, longitude=-18.080000, date=[1925, 6, 17, 8.830000], cruise=843883, uid=325, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=66.350000, longitude=-18.320000, date=[1925, 6, 17, 12.500000], cruise=843883, uid=327, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=66.280000, longitude=-19.220000, date=[1925, 6, 17, 20.000000], cruise=843883, uid=331, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=66.180000, longitude=-20.170000, date=[1925, 6, 18, 0.500000], cruise=843883, uid=350, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=65.720000, longitude=-20.370000, date=[1925, 6, 18, 7.500000], cruise=843883, uid=351, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=66.080000, longitude=-20.930000, date=[1925, 6, 18, 13.500000], cruise=843883, uid=356, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=66.350000, longitude=-21.370000, date=[1925, 6, 18, 17.500000], cruise=843883, uid=358, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=66.530000, longitude=-22.050000, date=[1925, 6, 18, 23.000000], cruise=843883, uid=359, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=66.630000, longitude=-23.130000, date=[1925, 6, 19, 21.000000], cruise=843883, uid=378, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=66.600000, longitude=-23.380000, date=[1925, 6, 20, 1.750000], cruise=843883, uid=389, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=66.380000, longitude=-23.770000, date=[1925, 6, 20, 6.250000], cruise=843883, uid=392, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=65.830000, longitude=-23.950000, date=[1925, 6, 20, 14.500000], cruise=843883, uid=394, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=65.770000, longitude=-25.500000, date=[1925, 6, 20, 22.000000], cruise=843883, uid=396, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=65.270000, longitude=-24.780000, date=[1925, 6, 21, 5.420000], cruise=843883, uid=414, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=64.880000, longitude=-24.220000, date=[1925, 6, 21, 10.500000], cruise=843883, uid=418, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=64.550000, longitude=-23.430000, date=[1925, 6, 21, 19.000000], cruise=843883, uid=429, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=64.180000, longitude=-23.280000, date=[1925, 6, 22, 0.000000], cruise=843883, uid=462, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=64.230000, longitude=-22.220000, date=[1925, 6, 22, 6.000000], cruise=843883, uid=467, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=64.230000, longitude=-22.220000, date=[1925, 6, 24, 5.670000], cruise=843883, uid=503, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=64.130000, longitude=-22.400000, date=[1925, 6, 24, 11.000000], cruise=843883, uid=510, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=64.100000, longitude=-22.570000, date=[1925, 6, 24, 15.000000], cruise=843883, uid=512, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=63.870000, longitude=-22.820000, date=[1925, 6, 26, 1.500000], cruise=843883, uid=526, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=63.800000, longitude=-23.080000, date=[1925, 6, 26, 7.000000], cruise=843883, uid=528, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=63.670000, longitude=-22.800000, date=[1925, 6, 26, 23.000000], cruise=843883, uid=535, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=63.730000, longitude=-21.580000, date=[1925, 6, 27, 8.170000], cruise=843883, uid=547, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=63.320000, longitude=-20.800000, date=[1925, 6, 27, 16.000000], cruise=843883, uid=549, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=63.570000, longitude=-20.430000, date=[1925, 6, 27, 22.000000], cruise=843883, uid=550, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=63.300000, longitude=-20.080000, date=[1925, 6, 30, 13.000000], cruise=843883, uid=598, probe_type=7))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=63.420000, longitude=-19.420000, date=[1925, 6, 30, 21.000000], cruise=843883, uid=602, probe_type=7))
+        qc= [False, True, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False]
+
+        tcqc = []
+        for p in ds.threadProfiles:
+            tcqc.append(qctests.EN_track_check.test(p)[0])
+
+        assert numpy.array_equal(qc, tcqc), 'QC results do not match those produced by EN system'
+
+    def real_case_3_test(self):
+        '''
+        A real instance of a series of a track with a failed track check reject.
+        '''
+        ds.threadProfiles = []
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=46.230000, longitude=-7.430000, date=[1975, 6, 3, 17.000000], cruise=9710419, uid=841, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=21.820000, longitude=-17.330000, date=[1975, 6, 10, 16.250000], cruise=9710419, uid=1419, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=21.680000, longitude=-17.400000, date=[1975, 6, 10, 19.420000], cruise=9710419, uid=1433, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=21.220000, longitude=-17.430000, date=[1975, 6, 11, 9.250000], cruise=9710419, uid=1486, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=21.530000, longitude=-17.430000, date=[1975, 6, 12, 3.080000], cruise=9710419, uid=1543, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=21.330000, longitude=-17.450000, date=[1975, 6, 12, 4.420000], cruise=9710419, uid=1547, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=21.170000, longitude=-17.500000, date=[1975, 6, 12, 5.580000], cruise=9710419, uid=1548, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=21.000000, longitude=-17.580000, date=[1975, 6, 12, 7.080000], cruise=9710419, uid=1556, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.830000, longitude=-17.630000, date=[1975, 6, 12, 10.080000], cruise=9710419, uid=1566, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.670000, longitude=-17.630000, date=[1975, 6, 12, 11.330000], cruise=9710419, uid=1569, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.500000, longitude=-17.670000, date=[1975, 6, 12, 14.920000], cruise=9710419, uid=1584, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.330000, longitude=-17.650000, date=[1975, 6, 12, 19.250000], cruise=9710419, uid=1607, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.170000, longitude=-17.650000, date=[1975, 6, 12, 21.000000], cruise=9710419, uid=1610, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.000000, longitude=-17.570000, date=[1975, 6, 12, 22.250000], cruise=9710419, uid=1614, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.170000, longitude=-17.580000, date=[1975, 6, 14, 8.670000], cruise=9710419, uid=1739, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.200000, longitude=-17.620000, date=[1975, 6, 14, 18.000000], cruise=9710419, uid=1779, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.350000, longitude=-17.620000, date=[1975, 6, 15, 2.500000], cruise=9710419, uid=1804, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.100000, longitude=-17.600000, date=[1975, 6, 15, 14.920000], cruise=9710419, uid=1841, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.250000, longitude=-17.630000, date=[1975, 6, 15, 18.580000], cruise=9710419, uid=1851, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.250000, longitude=-17.600000, date=[1975, 6, 16, 5.000000], cruise=9710419, uid=1880, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.130000, longitude=-17.570000, date=[1975, 6, 16, 9.000000], cruise=9710419, uid=1899, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.380000, longitude=-17.630000, date=[1975, 6, 16, 19.330000], cruise=9710419, uid=1943, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.630000, longitude=-17.650000, date=[1975, 6, 17, 0.000000], cruise=9710419, uid=1961, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.250000, longitude=-17.600000, date=[1975, 6, 17, 19.330000], cruise=9710419, uid=2041, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.120000, longitude=-17.620000, date=[1975, 6, 18, 0.500000], cruise=9710419, uid=2059, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.180000, longitude=-17.500000, date=[1975, 6, 18, 21.580000], cruise=9710419, uid=2137, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.000000, longitude=-17.670000, date=[1975, 6, 19, 0.500000], cruise=9710419, uid=2159, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.170000, longitude=-17.700000, date=[1975, 6, 19, 2.500000], cruise=9710419, uid=2162, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.350000, longitude=-17.700000, date=[1975, 6, 19, 4.830000], cruise=9710419, uid=2171, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.500000, longitude=-17.700000, date=[1975, 6, 19, 6.500000], cruise=9710419, uid=2179, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.500000, longitude=-17.600000, date=[1975, 6, 19, 20.670000], cruise=9710419, uid=2273, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.620000, longitude=-17.650000, date=[1975, 6, 19, 22.250000], cruise=9710419, uid=2282, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19.920000, longitude=-17.500000, date=[1975, 6, 20, 21.580000], cruise=9710419, uid=2365, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.000000, longitude=-17.670000, date=[1975, 6, 21, 0.166944], cruise=9710419, uid=2376, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.170000, longitude=-17.700000, date=[1975, 6, 21, 2.420000], cruise=9710419, uid=2385, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.330000, longitude=-17.700000, date=[1975, 6, 21, 4.000000], cruise=9710419, uid=2392, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.500000, longitude=-17.700000, date=[1975, 6, 21, 6.170000], cruise=9710419, uid=2402, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.630000, longitude=-17.650000, date=[1975, 6, 21, 7.670000], cruise=9710419, uid=2409, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.500000, longitude=-17.580000, date=[1975, 6, 23, 9.330000], cruise=9710419, uid=2633, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.670000, longitude=-17.630000, date=[1975, 6, 23, 18.170000], cruise=9710419, uid=2698, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.900000, longitude=-17.480000, date=[1975, 6, 23, 20.170000], cruise=9710419, uid=2709, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.970000, longitude=-17.430000, date=[1975, 6, 24, 20.420000], cruise=9710419, uid=2806, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.800000, longitude=-17.430000, date=[1975, 6, 25, 0.500000], cruise=9710419, uid=2824, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.830000, longitude=-17.500000, date=[1975, 6, 26, 6.170000], cruise=9710419, uid=2928, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.920000, longitude=-17.500000, date=[1975, 6, 26, 10.170000], cruise=9710419, uid=2940, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.950000, longitude=-17.480000, date=[1975, 6, 27, 6.920000], cruise=9710419, uid=3016, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.670000, longitude=-17.630000, date=[1975, 6, 27, 14.670000], cruise=9710419, uid=3053, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.500000, longitude=-17.680000, date=[1975, 6, 27, 15.750000], cruise=9710419, uid=3061, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.330000, longitude=-17.650000, date=[1975, 6, 27, 16.920000], cruise=9710419, uid=3063, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.670000, longitude=-17.630000, date=[1975, 6, 27, 18.170000], cruise=9710419, uid=3070, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.000000, longitude=-17.570000, date=[1975, 6, 27, 19.170000], cruise=9710419, uid=3077, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19.830000, longitude=-17.500000, date=[1975, 6, 27, 20.170000], cruise=9710419, uid=3080, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19.670000, longitude=-17.450000, date=[1975, 6, 27, 21.330000], cruise=9710419, uid=3085, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19.500000, longitude=-17.400000, date=[1975, 6, 27, 22.420000], cruise=9710419, uid=3088, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.330000, longitude=-17.670000, date=[1975, 6, 28, 11.750000], cruise=9710419, uid=3112, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.000000, longitude=-17.580000, date=[1975, 6, 28, 13.330000], cruise=9710419, uid=3117, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19.830000, longitude=-17.500000, date=[1975, 6, 28, 14.830000], cruise=9710419, uid=3121, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19.670000, longitude=-17.450000, date=[1975, 6, 28, 15.920000], cruise=9710419, uid=3123, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19.500000, longitude=-17.570000, date=[1975, 6, 28, 17.000000], cruise=9710419, uid=3128, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19.330000, longitude=-17.330000, date=[1975, 6, 28, 18.000000], cruise=9710419, uid=3129, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19.170000, longitude=-17.300000, date=[1975, 6, 28, 19.000000], cruise=9710419, uid=3133, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=19.000000, longitude=-17.180000, date=[1975, 6, 28, 20.170000], cruise=9710419, uid=3135, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18.830000, longitude=-17.080000, date=[1975, 6, 28, 21.250000], cruise=9710419, uid=3140, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.600000, longitude=-17.630000, date=[1975, 6, 30, 6.330000], cruise=9710419, uid=3205, probe_type=1))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=20.650000, longitude=-17.650000, date=[1975, 6, 30, 19.500000], cruise=9710419, uid=3244, probe_type=1))
+        qc= [False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False]
+
+        tcqc = []
+        for p in ds.threadProfiles:
+            tcqc.append(qctests.EN_track_check.test(p)[0])
+
+        assert numpy.array_equal(qc, tcqc), 'QC results do not match those produced by EN system'
+
+    def real_case_4_test(self):
+        '''
+        A real instance of a series of a track with a failed track check reject.
+        '''
+        ds.threadProfiles = []
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=59.070000, longitude=-18.920000, date=[1975, 6, 1, 7.580000], cruise=5546547, uid=8104, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=59.270000, longitude=-18.730000, date=[1975, 6, 4, 18.430000], cruise=5546547, uid=8593, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=56.450000, longitude=-10.330000, date=[1975, 6, 7, 15.250000], cruise=5546547, uid=9026, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=57.280000, longitude=-13.120000, date=[1975, 6, 8, 2.830000], cruise=5546547, uid=9097, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=58.300000, longitude=-17.000000, date=[1975, 6, 8, 8.170000], cruise=5546547, uid=9137, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=57.750000, longitude=-14.770000, date=[1975, 6, 8, 10.050000], cruise=5546547, uid=9148, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=58.000000, longitude=-15.880000, date=[1975, 6, 8, 15.030000], cruise=5546547, uid=9182, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=57.580000, longitude=-14.670000, date=[1975, 6, 8, 21.080000], cruise=5546547, uid=9235, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=57.220000, longitude=-13.630000, date=[1975, 6, 9, 2.080000], cruise=5546547, uid=9278, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=56.450000, longitude=-10.780000, date=[1975, 6, 9, 15.020000], cruise=5546547, uid=9368, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=56.130000, longitude=-9.980000, date=[1975, 6, 9, 21.170000], cruise=5546547, uid=9410, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=59.020000, longitude=-19.200000, date=[1975, 6, 13, 9.580000], cruise=5546547, uid=9989, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=59.220000, longitude=-19.400000, date=[1975, 6, 16, 21.400000], cruise=5546547, uid=10516, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=58.770000, longitude=-19.420000, date=[1975, 6, 22, 8.150000], cruise=5546547, uid=11446, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=58.730000, longitude=-19.330000, date=[1975, 6, 23, 1.000000], cruise=5546547, uid=11580, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=58.850000, longitude=-19.400000, date=[1975, 6, 23, 10.250000], cruise=5546547, uid=11644, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=58.820000, longitude=-19.420000, date=[1975, 6, 24, 7.720000], cruise=5546547, uid=11821, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=58.820000, longitude=-19.380000, date=[1975, 6, 25, 9.670000], cruise=5546547, uid=12029, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=58.750000, longitude=-19.400000, date=[1975, 6, 26, 8.250000], cruise=5546547, uid=12208, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=58.830000, longitude=-19.620000, date=[1975, 6, 27, 9.000000], cruise=5546547, uid=12370, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=58.770000, longitude=-19.550000, date=[1975, 6, 28, 8.000000], cruise=5546547, uid=12515, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=58.750000, longitude=-19.580000, date=[1975, 6, 29, 7.920000], cruise=5546547, uid=12647, probe_type=2))
+        qc= [False, False, False, False, True, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False]
+
+        tcqc = []
+        for p in ds.threadProfiles:
+            tcqc.append(qctests.EN_track_check.test(p)[0])
+
+        assert numpy.array_equal(qc, tcqc), 'QC results do not match those produced by EN system'
+
+    def real_case_5_test(self):
+        '''
+        A real instance of a series of a track with a failed track check reject.
+        '''
+        ds.threadProfiles = []
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=-20.920000, longitude=112.862000, date=[1975, 6, 7, 18.000000], cruise=5670710, uid=9040, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=-19.350000, longitude=113.795000, date=[1975, 6, 8, 0.020000], cruise=5670710, uid=9077, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=-17.380000, longitude=114.162000, date=[1975, 6, 8, 6.000000], cruise=5670710, uid=9116, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=-15.500000, longitude=115.512000, date=[1975, 6, 8, 12.000000], cruise=5670710, uid=9164, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=-12.470000, longitude=114.800000, date=[1975, 6, 8, 18.000000], cruise=5670710, uid=9212, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=-10.980000, longitude=115.220000, date=[1975, 6, 9, 0.020000], cruise=5670710, uid=9257, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=-9.370000, longitude=115.580000, date=[1975, 6, 9, 7.000000], cruise=5670710, uid=9323, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=-7.750000, longitude=115.050000, date=[1975, 6, 9, 12.000000], cruise=5670710, uid=9360, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=-6.630000, longitude=116.700000, date=[1975, 6, 9, 18.000000], cruise=5670710, uid=9384, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=-3.700000, longitude=118.130000, date=[1975, 6, 10, 0.020000], cruise=5670710, uid=9451, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=-1.770000, longitude=118.780000, date=[1975, 6, 10, 6.000000], cruise=5670710, uid=9481, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=0.267000, longitude=119.220000, date=[1975, 6, 10, 12.000000], cruise=5670710, uid=9527, probe_type=2))
+        ds.threadProfiles.append(util.testingProfile.fakeProfile([0], [0], latitude=2.170000, longitude=119.480000, date=[1975, 6, 10, 18.000000], cruise=5670710, uid=9562, probe_type=2))
+        qc= [False, False, False, True, True, False, False, False, True, False, False, False, False]
+
+        tcqc = []
+        for p in ds.threadProfiles:
+            tcqc.append(qctests.EN_track_check.test(p)[0])
+
+        assert numpy.array_equal(qc, tcqc), 'QC results do not match those produced by EN system'
 

--- a/tests/EN_track_validation.py
+++ b/tests/EN_track_validation.py
@@ -67,8 +67,8 @@ class TestClass():
         profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=4, longitude=90, date=[1999, 12, 31, 4]))
         profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=3, longitude=90, date=[1999, 12, 31, 5]))
 
-        trueSpeeds = [-1]
-        trueAngles = [-1, 0, 0, 0, math.pi, None]
+        trueSpeeds = [None]
+        trueAngles = [None, 0, 0, 0, math.pi, None]
 
         for i in range(len(profiles)-1):
             trueDistance = util.geo.haversineDistance(profiles[i], profiles[i+1])

--- a/tests/EN_track_validation.py
+++ b/tests/EN_track_validation.py
@@ -7,84 +7,94 @@ import qctests.EN_track_check
 import util.geo
 
 class TestClass():
-    # def setUp(self):
-
     distRes = 20000. #meters
     timeRes = 600.   #seconds
 
-    #     # #create an incorrectly formatted list of input files
-    #     # file = open("notalist.json", "w")
-    #     # file.write('{"not": "alist"}')
-    #     # file.close()
+    # some fake profiles
+    profiles = []
+    # first 5 profiles in a straight line
+    profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=0, longitude=90, date=[1999, 12, 31, 0]))
+    profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=1, longitude=90, date=[1999, 12, 31, 1]))
+    profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=2, longitude=90, date=[1999, 12, 31, 2]))
+    profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=3, longitude=90, date=[1999, 12, 31, 3]))
+    profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=4, longitude=90, date=[1999, 12, 31, 4]))
+    # reverse one
+    profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=3, longitude=90, date=[1999, 12, 31, 5]))
 
-    #     # #create a list of input files that does not exist
-    #     # file = open("dne.json", "w")
-    #     # file.write('["data/doesnotexist.dat"]')
-    #     # file.close()
-
-    #     # #create an artificial profile to trigger the temperature flag
-    #     # #sets first temperature to 99.9; otherwise identical to data/example.dat
-    #     # file = open("temp.dat", "w")
-    #     # file.write('C41303567064US5112031934 8 744210374426193562-17227140 6110101201013011182205814\n')
-    #     # file.write('01118220291601118220291901024721 8STOCS85A3 41032151032165-500632175-50023218273\n')
-    #     # file.write('18117709500110134401427143303931722076210220602291107291110329977020133023846181\n')
-    #     # file.write('24421800132207614110217330103192220521322011216442103723077095001101818115508527\n')
-    #     # file.write('20012110000133312500021011060022022068002272214830228442684000230770421200000191\n')
-    #     # file.write('15507911800121100001333125000151105002103302270022022068002274411816302284426840\n')
-    #     # file.write('00230770426500000191155069459001211000013331250001511050021033011300220220680022\n')
-    #     # file.write('73319043022844268400023077042620000019116601596680012110000133312500021022016002\n')
-    #     # file.write('17110100220220680022733112830228442684000230770435700000181155088803001211000013\n')
-    #     # file.write('33125000210220160022022068002273311283022844268400023077042120000019115508880300\n')
-    #     # file.write('12110000133312500015110200210330535002202206800227441428030228442684000230770421\n')
-    #     # file.write('20000019115508880300121100001333125000152204300210220320022022068002273312563022\n')
-    #     # file.write('84426840002307704212000001911550853710012110000133312500015110200210220160022022\n')
-    #     # file.write('06800227331128302284426840002307704212000001100001319990044230900033267500222650\n')
-    #     # file.write('03312050033281000220100033289500442309000332670002227100331123003328100022025002\n')
-    #     # file.write('22900044231910033286200222900033115400332810002205000342-12300442324100332728003\n')
-    #     # file.write('32117003312560033280500                                                         \n')
-    #     # file.close()
-
-
-    #     # return
-
-    # def tearDown(self):
-
-    #     return
 
     def trackSpeed_test(self):
         '''
         spot check on trackSpeed function
         '''
 
-        first = util.testingProfile.fakeProfile([0], [0], latitude=0, longitude=90, date=[1999, 12, 31, 0])
-        last =  util.testingProfile.fakeProfile([0], [0], latitude=1, longitude=90, date=[1999, 12, 31, 1])
-
-        trueDistance = util.geo.haversineDistance(first, last)
+        trueDistance = util.geo.haversineDistance(self.profiles[0], self.profiles[1])
         trueSpeed = (trueDistance - self.distRes)/max(3600., self.timeRes)
 
-        assert qctests.EN_track_check.trackSpeed(first, last) == trueSpeed
+        assert qctests.EN_track_check.trackSpeed(self.profiles[0], self.profiles[1]) == trueSpeed
 
     def detectExcessiveSpeed_test(self):
         '''
         spot checks on excessive speed flag
         '''
 
-        speeds = [10,9,9,20]
-        angles = [math.pi, math.pi/4, math.pi/4]
+        speeds = [-1, 10,9,9,9,20]
+        angles = [-1, 0, math.pi, 0, 0, None]
 
-        assert qctests.EN_track_check.detectExcessiveSpeed(speeds, angles, 0, 2), 'failed to flag a speed in excess of max speed'
-        assert qctests.EN_track_check.detectExcessiveSpeed(speeds, angles, 1, 10), 'failed to flag moderate speed at high angle'
-        assert not qctests.EN_track_check.detectExcessiveSpeed(speeds, angles, 2, 10), 'flagged a moderate speed at small angle'
-
-
+        assert qctests.EN_track_check.detectExcessiveSpeed(speeds, angles, 1, 2), 'failed to flag a speed in excess of max speed'
+        assert qctests.EN_track_check.detectExcessiveSpeed(speeds, angles, 2, 10), 'failed to flag moderate speed at high angle'
+        assert not qctests.EN_track_check.detectExcessiveSpeed(speeds, angles, 4, 10), 'flagged a moderate speed at small angle'
 
 
+    def calculateTraj_test(self):
+        '''
+        spot check on trajectory summary
+        '''
 
+        trueSpeeds = [-1]
+        trueAngles = [-1, 0, 0, 0, math.pi, None]
 
+        for i in range(len(self.profiles)-1):
+            trueDistance = util.geo.haversineDistance(self.profiles[i], self.profiles[i+1])
+            trueSpeed = (trueDistance - self.distRes)/max(3600., self.timeRes)
+            trueSpeeds.append(trueSpeed)
 
+        speeds, angles = qctests.EN_track_check.calculateTraj(self.profiles)
 
+        assert numpy.array_equal(speeds, trueSpeeds)
+        assert numpy.array_equal(angles, trueAngles)
 
+    def condition_a_fast_test(self):
+        '''
+        condition a checks that the speed from 2->3 isn't too fast
+        '''
 
+        profiles = []
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=0, longitude=90, date=[1999, 12, 31, 0]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=0.01, longitude=90, date=[1999, 12, 31, 1]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=1, longitude=90, date=[1999, 12, 31, 2]))
+
+        speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
+
+        flag = qctests.EN_track_check.condition_a(profiles, speeds, angles, 1, 15)
+
+        assert flag == 1, 'should have rejected the second profile due to high speed from second to third profile.'
+
+    def condition_a_angle_test(self):
+        '''
+        condition a checks that the angle at 3 isn't too large
+        '''
+
+        profiles = []
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=0, longitude=90, date=[1999, 12, 31, 0]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=0.5, longitude=90, date=[1999, 12, 31, 1]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=1, longitude=90, date=[1999, 12, 31, 2]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=0.5, longitude=90, date=[1999, 12, 31, 3]))
+
+        speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
+
+        flag = qctests.EN_track_check.condition_a(profiles, speeds, angles, 1, 15)
+
+        assert flag == 1, 'should have rejected the second profile due to high angle at third profile.'
 
 
 

--- a/tests/EN_track_validation.py
+++ b/tests/EN_track_validation.py
@@ -755,7 +755,7 @@ class TestClass():
 
     def unusual_case_no_time_test(self):
         '''
-        spot check on handling of profiles with incomplete data
+        spot check on handling of profiles with incomplete data (missing time)
         '''
 
         # Some fake profiles
@@ -770,7 +770,7 @@ class TestClass():
 
     def unusual_case_identical_positions_test(self):
         '''
-        spot check on handling of profiles with incomplete data
+        spot check on handling of profiles with incomplete data (identical positions)
         '''
 
         # Some fake profiles
@@ -782,7 +782,7 @@ class TestClass():
 
     def unusual_case_identical_times_test(self):
         '''
-        spot check on handling of profiles with incomplete data
+        spot check on handling of profiles with incomplete data (identical times)
         '''
 
         # Some fake profiles

--- a/tests/EN_track_validation.py
+++ b/tests/EN_track_validation.py
@@ -351,3 +351,69 @@ class TestClass():
         flag = qctests.EN_track_check.condition_f(profiles, speeds, angles, 4, 15)
         
         assert flag == 4, 'speed 4 too fast, speed 5 very small -> should reject 4'
+
+    def condition_g_test(self):
+        '''
+        nominal behavior of condition g
+        '''
+
+        profiles = []
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 5]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 31, 6]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 7]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=10, longitude=90, date=[1999, 12, 31, 8]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 9]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 10]))
+
+        speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
+    
+        flag = qctests.EN_track_check.condition_g(profiles, speeds, angles, 4, 15)
+
+        assert flag == 3, 'positions 2, 4 and 5 all closely clustered but 3 far away -> should reject 3'
+
+        profiles = []
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 5]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 31, 6]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 7]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 8]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=10, longitude=90, date=[1999, 12, 31, 9]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 10]))
+
+        speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
+        
+        flag = qctests.EN_track_check.condition_g(profiles, speeds, angles, 4, 15)
+        
+        assert flag == 4, 'positions 2, 3 and 5 closely clustered but 4 far away -> should reject 4'
+
+    def condition_h_test(self):
+        '''
+        nominal behavior of condition h
+        '''
+
+        profiles = []
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 5]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 31, 6]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 7]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 8]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18, longitude=90, date=[1999, 12, 31, 9]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18.5, longitude=90, date=[1999, 12, 31, 10]))
+
+        speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
+    
+        flag = qctests.EN_track_check.condition_h(profiles, speeds, angles, 4, 15)
+
+        assert flag == 3, 'nonsmooth behavior at profile 3 -> should reject 3'
+
+        profiles = []
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16, longitude=90, date=[1999, 12, 31, 5]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=16.5, longitude=90, date=[1999, 12, 31, 6]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17, longitude=90, date=[1999, 12, 31, 7]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=17.5, longitude=90, date=[1999, 12, 31, 8]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18.5, longitude=90, date=[1999, 12, 31, 9]))
+        profiles.append(util.testingProfile.fakeProfile([0], [0], latitude=18.5, longitude=90, date=[1999, 12, 31, 10]))
+
+        speeds, angles = qctests.EN_track_check.calculateTraj(profiles)
+        
+        flag = qctests.EN_track_check.condition_h(profiles, speeds, angles, 4, 15)
+        
+        assert flag == 4, 'nonsmooth behavior at 4 -> should reject 4'

--- a/tests/geo_tests.py
+++ b/tests/geo_tests.py
@@ -1,0 +1,79 @@
+import util.geo as geo
+import util.testingProfile
+import math
+
+def test_deltaTime_dateAware():
+    '''
+    make sure deltaTime is coping with real dates correctly
+    '''
+
+    # 2 days on a leap year:
+    early = util.testingProfile.fakeProfile([0], [0], date=[2004, 2, 28, 0])
+    late  = util.testingProfile.fakeProfile([0], [0], date=[2004, 3, 1, 0])
+
+    diff = geo.deltaTime(early, late)
+    assert diff == 172800., 'incorrect date difference on leap year'
+
+    # 1 day on not a leap year:
+    early = util.testingProfile.fakeProfile([0], [0], date=[2005, 2, 28, 0])
+    late  = util.testingProfile.fakeProfile([0], [0], date=[2005, 3, 1, 0])
+
+    diff = geo.deltaTime(early, late)
+    assert diff == 86400., 'incorrect date difference on non-leap year'
+
+    # 30 days in June:
+    early = util.testingProfile.fakeProfile([0], [0], date=[2004, 6, 30, 0])
+    late  = util.testingProfile.fakeProfile([0], [0], date=[2004, 7, 1, 0])
+
+    diff = geo.deltaTime(early, late)
+    assert diff == 86400., 'should only be 1 day between June 30 and July 1'
+
+    # 31 days in July:
+    early = util.testingProfile.fakeProfile([0], [0], date=[2004, 7, 30, 0])
+    late  = util.testingProfile.fakeProfile([0], [0], date=[2004, 8, 1, 0])
+
+    diff = geo.deltaTime(early, late)
+    assert diff == 172800., 'should be 2 days between July 30 and August 1'
+
+def test_deltaTime_times():
+    '''
+    make sure deltaTime is dealing with times correctly
+    '''  
+
+    # same day, same time:
+    early = util.testingProfile.fakeProfile([0], [0], date=[2004, 2, 28, 0])
+    late  = util.testingProfile.fakeProfile([0], [0], date=[2004, 2, 28, 0])
+
+    diff = geo.deltaTime(early, late)
+    assert diff == 0., 'incorrect time difference for identical dates and times'
+
+    # same day, different time:
+    early = util.testingProfile.fakeProfile([0], [0], date=[2004, 2, 28, 0])
+    late  = util.testingProfile.fakeProfile([0], [0], date=[2004, 2, 28, 1.5])
+
+    diff = geo.deltaTime(early, late)
+    assert diff == 5400., 'incorrect time difference for identical dates and different times'
+
+
+    # earlier time on later day
+    early = util.testingProfile.fakeProfile([0], [0], date=[2005, 2, 27, 2])
+    late  = util.testingProfile.fakeProfile([0], [0], date=[2005, 2, 28, 1])
+
+    diff = geo.deltaTime(early, late)
+    assert diff == 82800., 'incorrect time difference for earlier times but later days'
+
+def test_haversineAngle():
+    '''
+    check some nominal behavior of great circle intersections.
+    '''
+
+    A = util.testingProfile.fakeProfile([0], [0], latitude=0, longitude=10)
+    B = util.testingProfile.fakeProfile([0], [0], latitude=0, longitude=20)
+    C = util.testingProfile.fakeProfile([0], [0], latitude=0, longitude=30)
+
+    angle = geo.haversineAngle(A,B,C) 
+    assert angle - math.pi < 0.000001, 'point on a circle had a non-zero angle between them: %f' % angle
+
+    C = util.testingProfile.fakeProfile([0], [0], latitude=90, longitude=20)
+    angle = geo.haversineAngle(A,B,C) 
+    assert angle - math.pi/2 < 0.000001, 'orthogonal great circles had an angle of %f between them.' % angle

--- a/tests/geo_tests.py
+++ b/tests/geo_tests.py
@@ -77,3 +77,10 @@ def test_haversineAngle():
     C = util.testingProfile.fakeProfile([0], [0], latitude=90, longitude=20)
     angle = geo.haversineAngle(A,B,C) 
     assert angle - math.pi/2 < 0.000001, 'orthogonal great circles had an angle of %f between them.' % angle
+
+def test_archaversine_domain():
+    '''
+    make sure archaversine does something sensible if it ends up with an argument of 1+epislon or -1-epsilon
+    '''
+
+    assert geo.arcHaversine(1.00000000000000004) == geo.arcHaversine(1.0), 'archaversine fooled by floating point problems'

--- a/tests/main_tests.py
+++ b/tests/main_tests.py
@@ -3,6 +3,7 @@ import os
 from wodpy import wod
 import numpy, pandas
 from pandas.util.testing import assert_frame_equal
+import util.testingProfile
 
 class TestClass():
     def setUp(self):
@@ -208,6 +209,30 @@ class TestClass():
         assert numpy.array_equal(truth, [0,1,2,3,4,5,6,7])
         assert numpy.array_equal(results, [ [100,101, 200,201, 300,301, 400,401], [102,103, 202,203, 302,303, 402,403], [104,105, 204,205, 304,305, 404,405] ])
         assert numpy.array_equal(ids, [992, 993, 994, 995, 996, 997, 998, 999])
+
+    def sortHeaders_test(self):
+        '''
+        check basic behavior of header sorting
+        '''
+
+        p = []
+
+        p.append(util.testingProfile.fakeProfile([0], [0], date=[2004, 3, 17, 11.3], cruise=1))
+        p.append(util.testingProfile.fakeProfile([0], [0], date=[2004, 3, 17, 22.6], cruise=1))
+        p.append(util.testingProfile.fakeProfile([0], [0], date=[2004, 3, 17, 1.1], cruise=1))
+        p.append(util.testingProfile.fakeProfile([0], [0], date=[2004, 3, 17, 15.9], cruise=1))
+        p.append(util.testingProfile.fakeProfile([0], [0], date=[2005, 1, 11, 11.5], cruise=2))
+        p.append(util.testingProfile.fakeProfile([0], [0], date=[2005, 1, 11, 22.2], cruise=2))
+        p.append(util.testingProfile.fakeProfile([0], [0], date=[2005, 1, 11, 1.0], cruise=2))
+        p.append(util.testingProfile.fakeProfile([0], [0], date=[2005, 1, 11, 16.0], cruise=2))
+
+        sortedProfiles = main.sort_headers(p)
+
+        truth = {1: [p[2], p[0], p[3], p[1]],
+            2: [p[6], p[4], p[7], p[5]],
+        }
+
+        assert sortedProfiles == truth, 'incorrectly sorted profiles'
 
 def dummy(x):
     return [2*x, 3*x], [4*x, 5*x]

--- a/util/geo.py
+++ b/util/geo.py
@@ -1,0 +1,99 @@
+
+from datetime import datetime
+import numpy as np
+import math
+
+def haversine(theta):
+    '''
+    haversine.
+    '''
+
+    return math.sin(theta/2)**2
+
+def arcHaversine(hs):
+    '''
+    inverts haversine
+    '''
+
+    return 2 * math.asin(math.sqrt(hs))
+
+def haversineDistance(pro1, pro2):
+    """
+    Calculate the great circle distance in meters between two points 
+    on the earth (specified in decimal degrees)
+    implementation from http://gis.stackexchange.com/questions/44064/how-to-calculate-distances-in-a-point-sequence
+    """
+
+    lon1 = pro1.longitude()
+    lat1 = pro1.latitude()
+    lon2 = pro2.longitude()
+    lat2 = pro2.latitude()
+
+    # convert decimal degrees to radians 
+    lon1, lat1, lon2, lat2 = map(math.radians, [lon1, lat1, lon2, lat2])
+    # haversine formula 
+    dlon = lon2 - lon1 
+    dlat = lat2 - lat1 
+    a = haversine(dlat) + math.cos(lat1) * math.cos(lat2) * haversine(dlon)
+    c = arcHaversine(a) 
+    km = 6367 * c
+    assert km >= 0, 'haversine returned negative distance'
+    return km*1000.
+
+def haversineAngle(pro1, pro2, pro3):
+    '''
+    Calculate the angle subtended by the great circle passing through pro1 and pro2,
+    with that passing through pro2 and pro3 (all the pro* are WOD profiles or headers)
+    return None if any required information is missing.
+    '''
+
+    if None in [pro1.latitude(), pro1.longitude()]:
+        return None
+    if None in [pro2.latitude(), pro2.longitude()]:
+        return None
+    if None in [pro3.latitude(), pro3.longitude()]:
+        return None
+
+    a = haversineDistance(pro1, pro2) / 6367000.
+    b = haversineDistance(pro2, pro3) / 6367000.
+    c = haversineDistance(pro3, pro1) / 6367000.
+
+    if a == 0 or b == 0:
+        return 0
+
+    C = arcHaversine( (haversine(c) - haversine(a-b)) / math.sin(a) / math.sin(b) )
+
+    return C
+
+def deltaTime(earlier, later):
+    '''
+    Calculate the time difference between two profiles, later and earlier,
+    in seconds.
+    return None if information is missing.
+    '''
+
+    if None in [earlier.year(), earlier.month(), earlier.day(), earlier.time()]:
+        return None
+    if None in [later.year(), later.month(), later.day(), later.time()]:
+        return None
+
+    eHour, eMinute, eSecond = parseTime(earlier.time())
+    lHour, lMinute, lSecond = parseTime(later.time())
+
+    early = datetime(year=earlier.year(), month=earlier.month(), day=earlier.day(), hour=eHour, minute=eMinute, second=eSecond )
+    late = datetime(year=later.year(), month=later.month(), day=later.day(), hour=lHour, minute=lMinute, second=lSecond )
+
+    timeDiff = (late - early).total_seconds()
+    assert timeDiff >= 0, 'early date %s is after later date %s' % (early, late)
+
+    return timeDiff
+
+def parseTime(time):
+    '''
+    convert a WOD time on [0,24) to ints: hour [0,23], minute [0, 59], second [0, 59]
+    '''
+    hour = np.floor(time)
+    minute = np.floor(time*60) % 60
+    second = np.floor(time*3600) % 60
+
+    return int(hour), int(minute), int(second)

--- a/util/geo.py
+++ b/util/geo.py
@@ -15,7 +15,11 @@ def arcHaversine(hs):
     inverts haversine
     '''
 
-    return 2 * math.asin(math.sqrt(hs))
+    sqrths = math.sqrt(hs)
+    if sqrths > 1:
+        sqrths = round(sqrths, 10)
+
+    return 2 * math.asin(sqrths)
 
 def haversineDistance(pro1, pro2):
     """

--- a/util/main.py
+++ b/util/main.py
@@ -240,7 +240,25 @@ def combineArrays(parallelResults):
 
   return truth, results, profileIDs
 
+def sort_headers(headers):
+  '''
+  takes a list of headers, and sorts them into a dictionary keyed by cruise number
+  containing a list of corresponding headers; 
+  header lists are then time sorted.
+  '''
 
+  sortedHeaders = {}
+
+  for header in headers:
+    if header.cruise() not in sortedHeaders.keys():
+      sortedHeaders[header.cruise()] = [header]
+    else:
+      sortedHeaders[header.cruise()].append(header)
+
+  for key in sortedHeaders.keys():
+    sortedHeaders[key] = sorted(sortedHeaders[key], key=lambda header: (header.year(), header.month(), header.day(), header.time()) )
+
+  return sortedHeaders
 
 
 


### PR DESCRIPTION
I'll be pushing progress on #54 to this pull request; still a long way to go, but some of the strategy is visible right now.

Unlike all the other qctests, `EN_track` requires all the profiles from a given cruise all at once. But, for performance, we don't want to load any given profile more than once. In order to approach this, I'm trying the following:

 - after loading the full list of profile primary headers, sort by cruise number.
 - instead of running the full suite of tests after loading each individual profile, load an entire cruise worth of profiles, make them available on the global data store, then run each test individually exactly as previous, profile by profile.
 - have `EN_track` write a copy of its results to the global data store. This way, the first time `EN_track` is called for a profile in a cruise, it can pull all the relevant profiles from the data store, run the qc check for the whole cruise, and on each subsequent call for the rest of the profiles in the cruise, the answer can be fetched and returned from the data store without actually rerunning the qc test.

The actual guts of `EN_track` aren't implemented yet, but just running this as-is seems to make the correct information available at the correct times, without any additional reads, and without adding any specifics of `EN_track` to the main routine. 

Some concerns:

 - sorting the profile primary headers by cruise number could get slow for a huge number of profiles. Can we perhaps safely assume that all the profiles for a given cruise are in the same file? Sorting a bunch of small lists is much faster than sorting one huge list.
 - This whole scheme assumes it won't be too cumbersome to load all the profiles for a single cruise. Good assumption / bad assumption?

@s-good: I'm going to forge ahead with this strategy if I don't hear from you; let me know if you anticipate any pitfalls here.