### PR TITLE
first pass at en-stability

### DIFF
--- a/tests/EN_stability_check_validation.py
+++ b/tests/EN_stability_check_validation.py
@@ -7,7 +7,7 @@ import numpy
 
 def test_mcdougallEOS():
     '''
-    check the test values provided in McDougall 2003
+    check the test values provided for the EOS in McDougall 2003
     '''
 
     eos = round(qctests.EN_stability_check.mcdougallEOS(35,25,2000), 6)
@@ -16,3 +16,34 @@ def test_mcdougallEOS():
     assert  eos == 1017.726743, 'mcdougallEOS(20,20,1000) should be 1017.726743, instead got %f' % eos
     eos = round(qctests.EN_stability_check.mcdougallEOS(40,12,8000), 6)
     assert  eos == 1062.928258, 'mcdougallEOS(40,12,8000) should be 1062.928258, instead got %f' % eos
+
+def test_mcdougall_potential_temperature():
+    '''
+    check the test values provided for the potential temperature approximation in McDougall 2003
+    '''
+
+    pt = round(qctests.EN_stability_check.potentialTemperature(35, 20, 2000), 6)
+    assert pt == 19.621967, 'potential temperarure for S = 35 psu, T = 20C, p = 2000 db should be 19621967, instead got %f' % pt
+
+def test_EN_stability_check_padded():
+    '''
+    check some behavior near the test values provided in McDougall
+    padded with the same level to avoid flagging the entire profile
+    '''
+
+    p = util.testingProfile.fakeProfile([13.5, 25.5, 20.4, 13.5, 13.5, 13.5, 13.5, 13.5, 13.5], [0, 10, 20, 30, 40, 50, 60, 70, 80], salinities=[40, 35, 20, 40, 40, 40, 40, 40, 40], pressures=[8000, 2000, 1000, 8000, 8000, 8000, 8000, 8000, 8000])
+    qc = qctests.EN_stability_check.test(p)
+    truth = numpy.ma.array([False, True, True, False, False, False, False, False, False], mask=False)
+    assert numpy.array_equal(qc, truth), 'failed to flag padded stability example'
+
+
+def test_EN_stability_check_unpadded():
+    '''
+    check same four levels as above,
+    but don't pad with extra levels, so that the whole profile ends up getting rejected at the last step.
+    '''
+
+    p = util.testingProfile.fakeProfile([13.5, 25.5, 20.4, 13.5], [0, 10, 20, 30], salinities=[40, 35, 20, 40], pressures=[8000, 2000, 1000, 8000])
+    qc = qctests.EN_stability_check.test(p)
+    truth = numpy.ma.array([True, True, True, True], mask=False)
+    assert numpy.array_equal(qc, truth), 'failed to flag unpadded stability example'

--- a/util/testingProfile.py
+++ b/util/testingProfile.py
@@ -6,13 +6,17 @@ class fakeProfile:
     implementations of qc-tests.
     '''
 
-    def __init__(self, temperatures, depths, latitude=None, longitude=None, date=[1999, 12, 31, 0], probe_type=None, salinities=None):
+    def __init__(self, temperatures, depths, latitude=None, longitude=None, date=[1999, 12, 31, 0], probe_type=None, salinities=None, pressures=None):
         self.temperatures = temperatures
         if salinities is None:
             self.salinities = np.ma.array(temperatures, mask=True)
         else:
             self.salinities = salinities
         self.depths = depths
+        if pressures is None:
+            self.pressures = np.ma.array(temperatures, mask=True)
+        else:
+            self.pressures = pressures
 
         self.primary_header = {}
         self.primary_header['Number of levels'] = len(depths)
@@ -44,6 +48,10 @@ class fakeProfile:
     def s(self):
         """ Returns a numpy masked array of salinities. """
         return self.var_data(self.salinities)
+
+    def p(self):
+        """ Returns a numpy masked array of salinities. """
+        return self.var_data(self.pressures)
 
     def z(self):
         """ Returns a numpy masked array of depths. """


### PR DESCRIPTION
This PR implements & tests EN_stability. A few concerns:

 - [the text](http://www.metoffice.gov.uk/hadobs/en3/OQCpaper.pdf) describing the test was a bit hard to follow; I assumed that the test for density spikes proceeded if and only if the first threshold failed (delta rho < -0.03 kg/m3) - otherwise, the subsequent spike check would always flag every level.
 - McDougall refers to salinity measured in psu, but the WOD definition document reports salinities as unitless; is there a unit conversion that needs to be done?

In other news - this completes all outstanding qc tests save the track check. The one clear result coming from our early machine learning study, is that we don't have enough qc tests implemented yet to make a final qc decision. With our current set of qc tests, about half of the profiles that should be flagged in *quota* never are. Let me know what other tests should be introduced, so we can get as many of them implemented as possible before Hamburg.