### PR TITLE
Infrastructure tweaks

### DIFF
--- a/AutoQC.py
+++ b/AutoQC.py
@@ -82,24 +82,6 @@ def generateLogfile(verbose, trueVerbose, profiles, testNames):
 
     logfile.write('-----------------------------------------\n')
 
-def parallel_function(f):
-    '''
-    thanks http://scottsievert.github.io/blog/2014/07/30/simple-python-parallelism/
-    '''
-    def easy_parallize(f, sequence):
-        """ assumes f takes sequence as input, easy w/ Python's scope """
-        from multiprocessing import Pool
-        pool = Pool(processes=int(sys.argv[2])) # depends on available cores
-        result = pool.map(f, sequence) # for i in sequence: result[i] = f(i)
-        cleaned = [x for x in result if not x is None] # getting results
-        cleaned = np.asarray(cleaned)
-        pool.close() # not optimal! but easy
-        pool.join()
-        return cleaned
-    from functools import partial
-    return partial(easy_parallize, f)
-
-
 def processFile(fName):
   profiles = main.extractProfiles([fName])
   print('{} profiles will be read'.format(len(profiles)))
@@ -175,7 +157,7 @@ def processFile(fName):
 filenames = main.readInput('datafiles.json')
 
 if len(sys.argv)>2:
-  processFile.parallel = parallel_function(processFile)
+  processFile.parallel = main.parallel_function(processFile, sys.argv[2])
   parallel_result = processFile.parallel(filenames)
   #recombine results
   truth = parallel_result[0][0]

--- a/AutoQC.py
+++ b/AutoQC.py
@@ -116,6 +116,7 @@ def processFile(fName):
   testVerbose  = []
   trueResults  = []
   trueVerbose  = []
+  profileIDs   = []
   firstProfile = True
   delete       = []
   currentFile  = ''
@@ -146,6 +147,7 @@ def processFile(fName):
     truth = main.referenceResults([p])
     trueResults.append(truth[0][0])
     trueVerbose.append(truth[1][0])
+    profileIDs.append(p.uid())
     # Update user on progress.
     sys.stdout.write('{:5.1f}% complete\r'.format((iprofile+1)*100.0/len(profiles)))
     sys.stdout.flush()
@@ -161,7 +163,7 @@ def processFile(fName):
     print('Number of profiles that failed ' + testNames[i] + ' was %i' % np.sum(testResults[i]))
   print('Number of profiles that should have been failed was %i' % np.sum(trueResults))
 
-  return trueResults, testResults, testNames
+  return trueResults, testResults, testNames, profileIDs
 
 ########################################
 # main
@@ -179,8 +181,9 @@ if len(sys.argv)>2:
   truth = parallel_result[0][0]
   results = parallel_result[0][1]
   tests = parallel_result[0][2]
+  profileIDs = parallel_result[0][3]
 
-  main.generateCSV(truth, results, tests, sys.argv[1])
+  main.generateCSV(truth, results, tests, profileIDs, sys.argv[1])
 else:
   print 'Please add command line arguments to name your output file and set parallelization:'
   print 'python AutoQC myFile 4'

--- a/AutoQC.py
+++ b/AutoQC.py
@@ -6,9 +6,8 @@ import sys, os, json
 import util.combineTests as combinatorics
 import util.benchmarks as benchmarks
 import util.main as main
-import qctests.EN_background_check as EN_bkg
 
-def run(test, profiles, kwargs):
+def run(test, profiles):
   '''
   run <test> on a list of <profiles>, return an array summarizing when exceptions were raised
   '''
@@ -16,7 +15,7 @@ def run(test, profiles, kwargs):
   verbose = []
   exec('from qctests import ' + test)
   for profile in profiles:
-    exec('result = ' + test + '.test(profile, **kwargs)')
+    exec('result = ' + test + '.test(profile)')
 
     #demand tests returned bools:
     for i in result:
@@ -112,9 +111,6 @@ def processFile(fName):
   for testName in testNames:
     print(' {}'.format(testName))
 
-  # Set up any keyword arguments needed by tests.
-  kwargs = {}
-
   # run each test on each profile, and record its summary & verbose performance
   testResults  = []
   testVerbose  = []
@@ -138,7 +134,7 @@ def processFile(fName):
       continue
     # Run each test.    
     for itest, test in enumerate(testNames):
-      result = run(test, [p], kwargs)
+      result = run(test, [p])
       if firstProfile:
         testResults.append(result[0])
         testVerbose.append(result[1])

--- a/data/ds.py
+++ b/data/ds.py
@@ -87,5 +87,3 @@ def readWOD_temperature_ranges(filename='data/WOD_ranges_Temperature.csv'):
 regionCodes = readRegionCodes()
 cellCodes = readCellCodes()
 WODtempRanges = readWOD_temperature_ranges()
-
-records = {'backgroundAux':None}

--- a/data/ds.py
+++ b/data/ds.py
@@ -87,3 +87,5 @@ def readWOD_temperature_ranges(filename='data/WOD_ranges_Temperature.csv'):
 regionCodes = readRegionCodes()
 cellCodes = readCellCodes()
 WODtempRanges = readWOD_temperature_ranges()
+
+records = {'backgroundAux':None}

--- a/qctests/Argo_global_range_check.py
+++ b/qctests/Argo_global_range_check.py
@@ -5,7 +5,7 @@ system.
 See Argo quality control manual (based on version 2.5).
 """
 
-def test(p, **kwargs):
+def test(p):
     """ 
     Runs the quality control check on profile p and returns a numpy array 
     of quality control decisions with False where the data value has 

--- a/qctests/Argo_gradient_test.py
+++ b/qctests/Argo_gradient_test.py
@@ -4,7 +4,7 @@ Implements the gradient test on page 8 of http://w3.jcommops.org/FTPRoot/Argo/Do
 
 import numpy
 
-def test(p, **kwargs):
+def test(p):
     """
     Runs the quality control check on profile p and returns a numpy array
     of quality control decisions with False where the data value has

--- a/qctests/Argo_impossible_date_test.py
+++ b/qctests/Argo_impossible_date_test.py
@@ -7,7 +7,7 @@ The date criterion has been altered so that the test can be applied to all data 
 import numpy
 import calendar
 
-def test(p, **kwargs):
+def test(p):
     """
     Runs the quality control check on profile p and returns a numpy array
     of quality control decisions with False where the data value has

--- a/qctests/Argo_impossible_location_test.py
+++ b/qctests/Argo_impossible_location_test.py
@@ -5,7 +5,7 @@ Implements the impossible location test on page 6 of http://w3.jcommops.org/FTPR
 import numpy
 import calendar
 
-def test(p, **kwargs):
+def test(p):
     """
     Runs the quality control check on profile p and returns a numpy array
     of quality control decisions with False where the data value has

--- a/qctests/Argo_pressure_increasing_test.py
+++ b/qctests/Argo_pressure_increasing_test.py
@@ -8,7 +8,7 @@ http://w3.jcommops.org/FTPRoot/Argo/Doc/argo-quality-control-manual.pdf page 8.
 
 import numpy as np
 
-def test(p, **kwargs):
+def test(p):
     """ 
     Runs the quality control check on profile p and returns a numpy array 
     of quality control decisions with False where the data value has 

--- a/qctests/Argo_regional_range_test.py
+++ b/qctests/Argo_regional_range_test.py
@@ -6,7 +6,7 @@ import numpy
 import pyproj
 from shapely.geometry import Polygon, Point
 
-def test(p, **kwargs):
+def test(p):
     """
     Runs the quality control check on profile p and returns a numpy array
     of quality control decisions with False where the data value has

--- a/qctests/Argo_spike_test.py
+++ b/qctests/Argo_spike_test.py
@@ -4,7 +4,7 @@ Implements the spike test on page 8 of http://w3.jcommops.org/FTPRoot/Argo/Doc/a
 
 import numpy
 
-def test(p, **kwargs):
+def test(p):
     """
     Runs the quality control check on profile p and returns a numpy array
     of quality control decisions with False where the data value has

--- a/qctests/EN_background_check.py
+++ b/qctests/EN_background_check.py
@@ -16,7 +16,7 @@ def test(p, *args):
     """
 
     # Define an array to hold results.
-    qc    = np.zeros(p.n_levels(), dtype=bool)
+    qc = np.zeros(p.n_levels(), dtype=bool)
     
     # Find grid cell nearest to the observation.
     ilon, ilat = findGridCell(p, auxParam['lon'], auxParam['lat'])

--- a/qctests/EN_background_check.py
+++ b/qctests/EN_background_check.py
@@ -7,34 +7,26 @@ import EN_spike_and_step_check
 import numpy as np
 import util.obs_utils as outils
 from netCDF4 import Dataset
-import os
-import data.ds as ds
 
-def test(p, *args, **kwargs):
+def test(p, *args):
     """ 
     Runs the quality control check on profile p and returns a numpy array 
     of quality control decisions with False where the data value has 
     passed the check and True where it failed. 
     """
 
-    if ds.records['backgroundAux'] is None:
-        ds.records['backgroundAux'] = readENBackgroundCheckAux()
-
     # Define an array to hold results.
     qc    = np.zeros(p.n_levels(), dtype=bool)
     
-    # If we are here then the auxiliary information is available.
-    aux = ds.records['backgroundAux']
-    
     # Find grid cell nearest to the observation.
-    ilon, ilat = findGridCell(p, aux['lon'], aux['lat'])
+    ilon, ilat = findGridCell(p, auxParam['lon'], auxParam['lat'])
         
     # Extract the relevant auxiliary data.
     imonth = p.month() - 1
-    clim = aux['clim'][:, ilat, ilon, imonth]
-    bgev = aux['bgev'][:, ilat, ilon]
-    obev = aux['obev']
-    depths = aux['depth']
+    clim = auxParam['clim'][:, ilat, ilon, imonth]
+    bgev = auxParam['bgev'][:, ilat, ilon]
+    obev = auxParam['obev']
+    depths = auxParam['depth']
     
     # Remove missing data points.
     iOK = (clim.mask == False) & (bgev.mask == False)
@@ -147,6 +139,7 @@ def readENBackgroundCheckAux():
     '''
     Reads auxiliary information needed by the EN background check.
     '''
+
     filename = 'data/EN_bgcheck_info.nc'
     nc = Dataset(filename)
     data = {}
@@ -161,3 +154,5 @@ def readENBackgroundCheckAux():
     return data
 
 
+#import parameters on load
+auxParam = readENBackgroundCheckAux()

--- a/qctests/EN_constant_value_check.py
+++ b/qctests/EN_constant_value_check.py
@@ -5,7 +5,7 @@ system, described on page 7 of http://www.metoffice.gov.uk/hadobs/en3/OQCpaper.p
 
 import numpy
 
-def test(p, **kwargs):
+def test(p):
     """ 
     Runs the quality control check on profile p and returns a numpy array 
     of quality control decisions with False where the data value has 

--- a/qctests/EN_range_check.py
+++ b/qctests/EN_range_check.py
@@ -3,7 +3,7 @@ Implements the global range check used in the EN quality control
 system. 
 """
 
-def test(p, **kwargs):
+def test(p):
     """ 
     Runs the quality control check on profile p and returns a numpy array 
     of quality control decisions with False where the data value has 

--- a/qctests/EN_spike_and_step_check.py
+++ b/qctests/EN_spike_and_step_check.py
@@ -10,7 +10,7 @@ remove these elements and include them within the background check code.
 
 import numpy as np
 
-def test(p, suspect=False, **kwargs):
+def test(p, suspect=False):
     """ 
     Runs the quality control check on profile p and returns a numpy array 
     of quality control decisions with False where the data value has 

--- a/qctests/EN_stability_check.py
+++ b/qctests/EN_stability_check.py
@@ -5,7 +5,7 @@ http://www.metoffice.gov.uk/hadobs/en3/OQCpaper.pdf
 
 import math, numpy
 
-def test(p, **kwargs):
+def test(p):
     """ 
     Runs the quality control check on profile p and returns a numpy array 
     of quality control decisions with False where the data value has 

--- a/qctests/WOD_gradient_check.py
+++ b/qctests/WOD_gradient_check.py
@@ -4,7 +4,7 @@ Implements the excessive gradient test on page 47 of http://data.nodc.noaa.gov/w
 
 import numpy
 
-def test(p, **kwargs):
+def test(p):
     """
     Runs the quality control check on profile p and returns a numpy array
     of quality control decisions with False where the data value has

--- a/qctests/WOD_range_check.py
+++ b/qctests/WOD_range_check.py
@@ -5,7 +5,7 @@ pp 46 http://data.nodc.noaa.gov/woa/WOD/DOC/wodreadme.pdf
 import numpy
 import data.ds as ds
 
-def test(p, **kwargs):
+def test(p):
     """ 
     Runs the quality control check on profile p and returns a numpy array 
     of quality control decisions with False where the data value has 

--- a/tests/EN_background_check_validation.py
+++ b/tests/EN_background_check_validation.py
@@ -10,11 +10,8 @@ def test_EN_background_check_temperature():
     Make sure EN_background_check is flagging temperature excursions
     '''
 
-    kwargs = {}
-    main.readENBackgroundCheckAux(['EN_background_check'], kwargs)
-
     p = util.testingProfile.fakeProfile([1.8, 1.8, 1.8, 7.1], [0.0, 2.5, 5.0, 7.5], latitude=55.6, longitude=12.9, date=[1900, 01, 15, 0], probe_type=7) 
-    qc = qctests.EN_background_check.test(p, **kwargs)
+    qc = qctests.EN_background_check.test(p)
     expected = [False, False, False, True]
     assert numpy.array_equal(qc, expected), 'mismatch between qc results and expected values'
 

--- a/tests/main_tests.py
+++ b/tests/main_tests.py
@@ -157,3 +157,22 @@ class TestClass():
 
         assert ref[0][0] == False, 'incorrect extraction of overall reference result for data/example.dat'
         assert numpy.array_equal(ref[1][0], [False, False, False, False] ), 'incorrect extraction of verbose reference results for data/example.dat'
+
+    def generateCSV_test(self):
+        '''
+        make sure things are being packed into dataframes correctly;
+        assumes Pandas writes dataframes to csv correctly. 
+        '''
+
+        truth = [True, False, True]
+        results = [
+            [False, False, False],
+            [True, True, True]
+        ]
+        tests = ['x', 'y']
+
+        df = main.generateCSV(truth, results, tests, 'test')
+
+        print df['x']
+
+        assert False

--- a/tests/main_tests.py
+++ b/tests/main_tests.py
@@ -173,6 +173,6 @@ class TestClass():
 
         df = main.generateCSV(truth, results, tests, 'test')
 
-        print df['x']
+        print df
 
         assert False

--- a/tests/main_tests.py
+++ b/tests/main_tests.py
@@ -1,7 +1,8 @@
 import util.main as main
 import os
 from wodpy import wod
-import numpy
+import numpy, pandas
+from pandas.util.testing import assert_frame_equal
 
 class TestClass():
     def setUp(self):
@@ -164,15 +165,18 @@ class TestClass():
         assumes Pandas writes dataframes to csv correctly. 
         '''
 
-        truth = [True, False, True]
+        truth = [True, False, False]
         results = [
             [False, False, False],
             [True, True, True]
         ]
         tests = ['x', 'y']
+        keys = [1000,1001,1002]
 
-        df = main.generateCSV(truth, results, tests, 'test')
+        df = main.generateCSV(truth, results, tests, keys, 'test')
+        dfTrue = pandas.DataFrame([[True, False, True],[False, False, True],[False, False, True]], index=keys, columns=['True Flags', 'x', 'y'])
 
-        print df
+        assert_frame_equal(df, dfTrue, check_names=True)
 
-        assert False
+
+

--- a/tests/main_tests.py
+++ b/tests/main_tests.py
@@ -178,5 +178,22 @@ class TestClass():
 
         assert_frame_equal(df, dfTrue, check_names=True)
 
+    def parallelization_test(self):
+        '''
+        simple test to check parallelization infrastructure
+        '''
+
+        dummy.parallel = main.parallel_function(dummy)
+        parallel_result = dummy.parallel([1,2])
+
+        assert numpy.array_equal(parallel_result[0][0], [2,3])
+        assert numpy.array_equal(parallel_result[0][1], [4,5])
+        assert numpy.array_equal(parallel_result[1][0], [4,6])
+        assert numpy.array_equal(parallel_result[1][1], [8,10])
+
+def dummy(x):
+    return [2*x, 3*x], [4*x, 5*x]
+
+
 
 

--- a/util/main.py
+++ b/util/main.py
@@ -89,7 +89,7 @@ def referenceResults(profiles):
   return [refResult, verbose]
 
 
-def generateCSV(truth, results, tests, name):
+def generateCSV(truth, results, tests, primaryKeys, name):
   '''
   log resuls as a CSV, columns for tests, rows for profiles.
   '''
@@ -98,7 +98,8 @@ def generateCSV(truth, results, tests, name):
   for i, testName in enumerate(tests):
     d[testName] = results[i]
 
-  df = pandas.DataFrame(d)
+  df = pandas.DataFrame(d, index=primaryKeys)
+
   df.insert(0, 'True Flags', truth)
 
   df.to_csv('results-' + name + '.csv')

--- a/util/main.py
+++ b/util/main.py
@@ -1,10 +1,9 @@
 ## helper functions used in the top level AutoQC.py
 
-import json, os, glob, time
+import json, os, glob, time, pandas, csv
 import numpy as np
 from wodpy import wod
 from netCDF4 import Dataset
-import csv
 
 def readInput(JSONlist):
     '''Create a list of data file names from a json array.'''
@@ -89,22 +88,19 @@ def referenceResults(profiles):
     verbose.append(refAssessment)
   return [refResult, verbose]
 
-def readENBackgroundCheckAux(testNames, kwargs):
-  '''
-  Reads auxiliary information needed by the EN background check.
-  '''
-  filename = 'data/EN_bgcheck_info.nc'
-  if 'EN_background_check' in testNames and os.path.isfile(filename):
-    nc = Dataset(filename)
-    data = {}
-    data['lon']   = nc.variables['longitude'][:]
-    data['lat']   = nc.variables['latitude'][:]
-    data['depth'] = nc.variables['depth'][:]
-    data['month'] = nc.variables['month'][:]
-    data['clim']  = nc.variables['potm_climatology'][:]
-    data['bgev']  = nc.variables['bg_err_var'][:]
-    data['obev']  = nc.variables['ob_err_var'][:]
-    kwargs['EN_background_check_aux'] = data
-  else:
-    kwargs['EN_background_check_aux'] = None
 
+def generateCSV(truth, results, tests, name):
+  '''
+  log resuls as a CSV, columns for tests, rows for profiles.
+  '''
+
+  d = {}
+  for i, testName in enumerate(tests):
+    d[testName] = results[i]
+
+  df = pandas.DataFrame(d)
+  df.insert(0, 'True Flags', truth)
+
+  df.to_csv('results-' + name + '.csv')
+
+  return df

--- a/util/main.py
+++ b/util/main.py
@@ -1,6 +1,6 @@
 ## helper functions used in the top level AutoQC.py
 
-import json, os, glob, time, pandas, csv
+import json, os, glob, time, pandas, csv, sys
 import numpy as np
 from wodpy import wod
 from netCDF4 import Dataset
@@ -105,3 +105,20 @@ def generateCSV(truth, results, tests, primaryKeys, name):
   df.to_csv('results-' + name + '.csv')
 
   return df # for testing
+
+def parallel_function(f, nfold=2):
+    '''
+    thanks http://scottsievert.github.io/blog/2014/07/30/simple-python-parallelism/
+    '''
+    def easy_parallize(f, sequence):
+        """ assumes f takes sequence as input, easy w/ Python's scope """
+        from multiprocessing import Pool
+        pool = Pool(processes=int(nfold)) # depends on available cores
+        result = pool.map(f, sequence) # for i in sequence: result[i] = f(i)
+        cleaned = [x for x in result if not x is None] # getting results
+        cleaned = np.asarray(cleaned)
+        pool.close() # not optimal! but easy
+        pool.join()
+        return cleaned
+    from functools import partial
+    return partial(easy_parallize, f)

--- a/util/main.py
+++ b/util/main.py
@@ -103,4 +103,4 @@ def generateCSV(truth, results, tests, name):
 
   df.to_csv('results-' + name + '.csv')
 
-  return df
+  return df # for testing


### PR DESCRIPTION
This PR makes some (hopefully final) infrastructural tweaks as we approach v1 by mid 2016:

 - kwargs arguments are dropped in favor of parameter stores encapsulated along with the relevant test; see `EN-background` for an example
 - a couple more infrstructural unit tests are added to ensure parallelization and CSV construction functions are proceeding as expected.
 - CSV now uses profile `uid()` as primary key (instead of just numbering the rows)
 - some usage help has been added
 - plus a few trivial tidy-ups.

There shouldn't be anything too controversial about this PR, I'm going to give it until Friday and merge it then if there are no problems.