### PR TITLE
added CSIRO gradient test

### DIFF
--- a/qctests/CSIRO_gradient.py
+++ b/qctests/CSIRO_gradient.py
@@ -1,0 +1,55 @@
+"""
+Implements the gradient test of DOI: 10.1175/JTECHO539.1
+All questionable features result in a flag, in order to minimize false negatives
+Spike check is ommitted atm. 
+"""
+
+import numpy
+
+def test(p):
+    """
+    Runs the quality control check on profile p and returns a numpy array
+    of quality control decisions with False where the data value has
+    passed the check and True where it failed.
+    """
+
+    # Get temperature values from the profile.
+    t = p.t()
+    # Get depth values (m) from the profile.
+    d = p.z()
+    # is this an xbt?
+    isXBT = p.probe_type() == 2
+
+    assert len(t.data) == len(d.data), 'Number of temperature measurements does not equal number of depth measurements.'
+
+    # initialize qc as a bunch of falses;
+    # implies all measurements pass when a gradient can't be calculated, such as at edges & gaps in data:
+    qc = numpy.zeros(len(t.data), dtype=bool)
+
+    # check for gaps in data
+    isTemperature = (t.mask==False)
+    isDepth = (d.mask==False)
+    isData = isTemperature & isDepth
+
+    for i in range(0,len(t.data)-1):
+        if isData[i] & isData[i+1] & (t.data[i+1] - t.data[i] > 0):
+
+            gradient = (d.data[i+1] - d.data[i]) / (t.data[i+1] - t.data[i]) 
+
+            # gradient flag
+            if gradient > -0.4 and gradient < 12.5:
+                qc[i] = True
+
+            # too-shallow temperatures on XBT probes
+            # note we simply flag this profile for manual QC, in order to minimize false negatives.
+            if isXBT and d.data[i] < 3.6:
+                qc[i] = True
+
+    # wire breaks at bottom of profile:
+    i = len(t.data)-1
+    if isTemperature[i] and isXBT:
+        if t.data[i] < -2.8 or t.data[i] > 36:
+            qc[i] = True
+
+
+    return qc


### PR DESCRIPTION
Implements an interpretation of the CSIRO gradient test described in [the paper](http://journals.ametsoc.org/doi/abs/10.1175/JTECHO539.1) recommended by @BecCowley. A few comments:

 - instead of making any replacements per the text, profiles with suspicious characteristics are simply flagged for further inspection, per our priority of minimizing false negatives.
 - I assumed the wire break criteria only applied to XBT probes, but I may have misinterpreted the text; let me know.
 - the spike check suggested in the text is not yet implemented; the exact algebraic definition of a spike was not immediately obvious from the text. Will try to deduce from the fortran.

This test seems simple enough that attempting to wrap the FORTRAN seemed unnecessary. Interestingly, even though we already have two other gradient checks, this one flags several profiles in the test `quota_subset` the others do not; it remains to analyze a full dataset to determine the nature of this sensitivity.