### PR TITLE
Tidying up output when using parallel running

### DIFF
--- a/AutoQC.py
+++ b/AutoQC.py
@@ -177,6 +177,11 @@ if len(sys.argv)>2:
   results = parallel_result[0][1]
   tests = parallel_result[0][2]
   profileIDs = parallel_result[0][3]
+  for pr in parallel_result[1:]:
+    truth      += pr[0]
+    for itr, tr in enumerate(pr[1]):
+      results[itr] += tr
+    profileIDs += pr[3]
 
   main.generateCSV(truth, results, tests, profileIDs, sys.argv[1])
 else:

--- a/AutoQC.py
+++ b/AutoQC.py
@@ -86,17 +86,6 @@ def processFile(fName):
   print('{} profiles will be read'.format(len(profiles)))
   print('')
 
-  # identify and import tests
-  testNames = main.importQC('qctests')
-  testNames.sort()
-
-  print('{} quality control checks have been found'.format(len(testNames)))
-  testNames = main.checkQCTestRequirements(testNames)
-  print('{} quality control checks are able to be run:'.format(len(testNames)))
-  for testName in testNames:
-    print('  {}'.format(testName))
-  print('')
-
   # run each test on each profile, and record its summary & verbose performance
   testResults  = []
   testVerbose  = []
@@ -157,12 +146,22 @@ def processFile(fName):
   tpr, fpr, fnr, tnr = main.calcRates(overallResults, trueResults)
   print('%30s %7i %6.1f%1s %6.1f%1s %6.1f%1s %6.1f%1s' % ('RESULT OF OR OF ALL:', np.sum(overallResults), tpr, '%', fpr, '%', tnr, '%', fnr, '%'))
 
-  return trueResults, testResults, testNames, profileIDs
+  return trueResults, testResults, profileIDs
 
 
 ########################################
 # main
 ########################################
+
+# identify and import tests
+testNames = main.importQC('qctests')
+testNames.sort()
+print('{} quality control checks have been found'.format(len(testNames)))
+testNames = main.checkQCTestRequirements(testNames)
+print('{} quality control checks are able to be run:'.format(len(testNames)))
+for testName in testNames:
+  print('  {}'.format(testName))
+print('')
 
 # identify data files and extract profile information into an array - this
 # information is used by some quality control checks; the profile data are
@@ -175,15 +174,14 @@ if len(sys.argv)>2:
   #recombine results
   truth = parallel_result[0][0]
   results = parallel_result[0][1]
-  tests = parallel_result[0][2]
-  profileIDs = parallel_result[0][3]
+  profileIDs = parallel_result[0][2]
   for pr in parallel_result[1:]:
     truth      += pr[0]
     for itr, tr in enumerate(pr[1]):
       results[itr] += tr
-    profileIDs += pr[3]
+    profileIDs += pr[2]
 
-  main.generateCSV(truth, results, tests, profileIDs, sys.argv[1])
+  main.generateCSV(truth, results, testNames, profileIDs, sys.argv[1])
 else:
   print 'Please add command line arguments to name your output file and set parallelization:'
   print 'python AutoQC myFile 4'

--- a/AutoQC.py
+++ b/AutoQC.py
@@ -100,13 +100,9 @@ def processFile(fName):
     # Load the profile data.
     p, currentFile, f = main.profileData(pinfo, currentFile, f)
     # Check that there are temperature data in the profile, otherwise skip.
-    # A record is kept of the empty profiles.
     if p.var_index() is None:
-      delete.append(iprofile)
       continue
-    main.catchFlags(p)
     if np.sum(p.t().mask == False) == 0:
-      delete.append(iprofile)
       continue
     # Run each test.    
     for itest, test in enumerate(testNames):
@@ -127,10 +123,6 @@ def processFile(fName):
     sys.stdout.write('QC of profiles is {:5.1f}% complete\r'.format((iprofile+1)*100.0/len(profiles)))
     sys.stdout.flush()
   # testResults[i][j] now contains a flag indicating the exception raised by test i on profile j
-
-  # Remove records of profiles with no temperature data.
-  for i in reversed(delete):
-    del profiles[i]
 
   return trueResults, testResults, profileIDs
 

--- a/AutoQC.py
+++ b/AutoQC.py
@@ -132,20 +132,6 @@ def processFile(fName):
   for i in reversed(delete):
     del profiles[i]
 
-  # Summary statistics
-  print('')
-  print('')
-  print('Number of profiles tested was %i' % len(profiles))
-  print('')
-  print('%30s %7s %7s %7s %7s %7s' % ('NAME OF TEST', 'FAILS', 'TPR', 'FPR', 'TNR', 'FNR')) 
-  overallResults = np.zeros(len(profiles), dtype=bool)
-  for i in range (0, len(testNames)):
-    overallResults = np.logical_or(overallResults, testResults[i])
-    tpr, fpr, fnr, tnr = main.calcRates(testResults[i], trueResults)
-    print('%30s %7i %6.1f%1s %6.1f%1s %6.1f%1s %6.1f%1s' % (testNames[i], np.sum(testResults[i]), tpr, '%', fpr, '%', tnr, '%', fnr, '%'))
-  tpr, fpr, fnr, tnr = main.calcRates(overallResults, trueResults)
-  print('%30s %7i %6.1f%1s %6.1f%1s %6.1f%1s %6.1f%1s' % ('RESULT OF OR OF ALL:', np.sum(overallResults), tpr, '%', fpr, '%', tnr, '%', fnr, '%'))
-
   return trueResults, testResults, profileIDs
 
 
@@ -180,6 +166,21 @@ if len(sys.argv)>2:
     for itr, tr in enumerate(pr[1]):
       results[itr] += tr
     profileIDs += pr[2]
+
+  # Summary statistics
+  nProfiles = len(truth)
+  print('')
+  print('')
+  print('Number of profiles tested was %i' % nProfiles)
+  print('')
+  print('%30s %7s %7s %7s %7s %7s' % ('NAME OF TEST', 'FAILS', 'TPR', 'FPR', 'TNR', 'FNR')) 
+  overallResults = np.zeros(nProfiles, dtype=bool)
+  for i in range (0, len(testNames)):
+    overallResults = np.logical_or(overallResults, results[i])
+    tpr, fpr, fnr, tnr = main.calcRates(results[i], truth)
+    print('%30s %7i %6.1f%1s %6.1f%1s %6.1f%1s %6.1f%1s' % (testNames[i], np.sum(results[i]), tpr, '%', fpr, '%', tnr, '%', fnr, '%'))
+  tpr, fpr, fnr, tnr = main.calcRates(overallResults, truth)
+  print('%30s %7i %6.1f%1s %6.1f%1s %6.1f%1s %6.1f%1s' % ('RESULT OF OR OF ALL:', np.sum(overallResults), tpr, '%', fpr, '%', tnr, '%', fnr, '%'))
 
   main.generateCSV(truth, results, testNames, profileIDs, sys.argv[1])
 else:

--- a/AutoQC.py
+++ b/AutoQC.py
@@ -23,69 +23,7 @@ def run(test, profiles):
     verbose.append(result)
   return [qcResults, verbose]
 
-def generateLogfile(verbose, trueVerbose, profiles, testNames):
-  '''
-  verbose[i][j][k] == result of test i on profile j at depth k
-  trueVerbose[j][k] == true result for profile j at depth k
-  <profiles> == array of profiles per `extractProfiles`
-  <testNames> == array of names returned by `importQC`
-  '''
-  # open a logfile
-  logfile = open('AutoQClog.' + time.strftime("%H%M%S"), 'w')
-
-  # log summary for each profile
-  for i in range (0, len(profiles)): # i counts profiles
-    with open(profiles[i].file_name) as f:
-      f.seek(profiles[i].file_position)
-      profile = wod.WodProfile(f)
-      
-    logfile.write('Profile ID: %i\n' % profiles[i].uid())
-
-    # title row
-    titleRow = 'Depth (m)  Temp (degC)'
-    formatString = '{0[0]:<20}{0[1]:<20}'
-    k = 2
-    for test in testNames:
-        titleRow += '  ' + test
-        formatString += '{0['+str(k)+']:<20}'
-        k += 1
-    titleRow += '  Reference'
-    formatString += '{0['+str(k)+']:<20}'
-    logfile.write(formatString.format(titleRow.split('  ')))
-    logfile.write('\n')
-
-    # row for each depth
-    for j in range (0,len(trueVerbose[i])): # j counts depth
-      formatString = '{0[0]:<20}{0[1]:<20}'
-      row = str(profile.z()[j]) + '  ' + str(profile.t()[j]) + '  '
-      for k in range (0, len(verbose)): # k counts tests
-        row += str(verbose[k][i][j])
-        row += '  '
-        formatString += '{0['+str(2+k)+']:<20}'
-      row += str(trueVerbose[i][j])
-      formatString += '{0['+str(2+len(verbose))+']:<20}'
-      logfile.write(formatString.format(row.split('  ')))
-      logfile.write('\n')
-
-    summaryRow = '  OVERALL RESULTS:  '
-    formatString = '{0[0]:<20}{0[1]:<20}'
-    for k in range (0, len(verbose)):
-      summaryRow += str(np.any(verbose[k][i]))
-      summaryRow += '  '
-      formatString += '{0['+str(2+k)+']:<20}'
-    summaryRow += str(np.any(trueVerbose[i]))
-    formatString += '{0['+str(2+len(verbose))+']:<20}'
-    logfile.write(formatString.format(summaryRow.split('  ')))
-    logfile.write('\n')
-
-    logfile.write('-----------------------------------------\n')
-
-
 def processFile(fName):
-  profiles = main.extractProfiles([fName])
-  print('{} profiles will be read'.format(len(profiles)))
-  print('')
-
   # run each test on each profile, and record its summary & verbose performance
   testResults  = []
   testVerbose  = []
@@ -93,7 +31,6 @@ def processFile(fName):
   trueVerbose  = []
   profileIDs   = []
   firstProfile = True
-  delete       = []
   currentFile  = ''
   f = None
   for iprofile, pinfo in enumerate(profiles):
@@ -139,14 +76,16 @@ testNames = main.checkQCTestRequirements(testNames)
 print('{} quality control checks are able to be run:'.format(len(testNames)))
 for testName in testNames:
   print('  {}'.format(testName))
-print('')
 
 # identify data files and extract profile information into an array - this
 # information is used by some quality control checks; the profile data are
 # read later.
 filenames = main.readInput('datafiles.json')
+profiles  = main.extractProfiles(filenames)
+print('\n{} profiles will be read\n'.format(len(profiles)))
 
 if len(sys.argv)>2:
+  nProcessed = 0
   processFile.parallel = main.parallel_function(processFile, sys.argv[2])
   parallel_result = processFile.parallel(filenames)
   #recombine results
@@ -159,21 +98,8 @@ if len(sys.argv)>2:
       results[itr] += tr
     profileIDs += pr[2]
 
-  # Summary statistics
-  nProfiles = len(truth)
-  print('')
-  print('')
-  print('Number of profiles tested was %i' % nProfiles)
-  print('')
-  print('%30s %7s %7s %7s %7s %7s' % ('NAME OF TEST', 'FAILS', 'TPR', 'FPR', 'TNR', 'FNR')) 
-  overallResults = np.zeros(nProfiles, dtype=bool)
-  for i in range (0, len(testNames)):
-    overallResults = np.logical_or(overallResults, results[i])
-    tpr, fpr, fnr, tnr = main.calcRates(results[i], truth)
-    print('%30s %7i %6.1f%1s %6.1f%1s %6.1f%1s %6.1f%1s' % (testNames[i], np.sum(results[i]), tpr, '%', fpr, '%', tnr, '%', fnr, '%'))
-  tpr, fpr, fnr, tnr = main.calcRates(overallResults, truth)
-  print('%30s %7i %6.1f%1s %6.1f%1s %6.1f%1s %6.1f%1s' % ('RESULT OF OR OF ALL:', np.sum(overallResults), tpr, '%', fpr, '%', tnr, '%', fnr, '%'))
-
+  # Print summary statistics and write output file.
+  main.printSummary(truth, results, testNames)
   main.generateCSV(truth, results, testNames, profileIDs, sys.argv[1])
 else:
   print 'Please add command line arguments to name your output file and set parallelization:'

--- a/util/main.py
+++ b/util/main.py
@@ -214,7 +214,7 @@ def calcRates(testResults, trueResults):
 def printSummary(truth, results, testNames):
 
   nProfiles = len(truth)
-  print('\n\nNumber of profiles tested was %i\n' % nProfiles)
+  print('Number of profiles tested was %i\n' % nProfiles)
   print('%30s %7s %7s %7s %7s %7s' % ('NAME OF TEST', 'FAILS', 'TPR', 'FPR', 'TNR', 'FNR')) 
   overallResults = np.zeros(nProfiles, dtype=bool)
   for i in range (0, len(testNames)):

--- a/util/main.py
+++ b/util/main.py
@@ -46,7 +46,9 @@ def profileData(pinfo, currentFile, f):
     currentFile = pinfo.file_name
     f = open(currentFile)
   if f.tell() != pinfo.file_position: f.seek(pinfo.file_position)
-  return wod.WodProfile(f), currentFile, f
+  profile = wod.WodProfile(f)
+  catchFlags(profile)
+  return profile, currentFile, f
 
 def importQC(dir):
   '''

--- a/util/main.py
+++ b/util/main.py
@@ -210,3 +210,17 @@ def calcRates(testResults, trueResults):
   tnr = nPP * 100.0 / nTruePasses
 
   return tpr, fpr, fnr, tnr 
+
+def printSummary(truth, results, testNames):
+
+  nProfiles = len(truth)
+  print('\n\nNumber of profiles tested was %i\n' % nProfiles)
+  print('%30s %7s %7s %7s %7s %7s' % ('NAME OF TEST', 'FAILS', 'TPR', 'FPR', 'TNR', 'FNR')) 
+  overallResults = np.zeros(nProfiles, dtype=bool)
+  for i in range (0, len(testNames)):
+    overallResults = np.logical_or(overallResults, results[i])
+    tpr, fpr, fnr, tnr = calcRates(results[i], truth)
+    print('%30s %7i %6.1f%1s %6.1f%1s %6.1f%1s %6.1f%1s' % (testNames[i], np.sum(results[i]), tpr, '%', fpr, '%', tnr, '%', fnr, '%'))
+  tpr, fpr, fnr, tnr = calcRates(overallResults, truth)
+  print('%30s %7i %6.1f%1s %6.1f%1s %6.1f%1s %6.1f%1s' % ('RESULT OF OR OF ALL:', np.sum(overallResults), tpr, '%', fpr, '%', tnr, '%', fnr, '%'))
+


### PR DESCRIPTION
The output to screen was not working well when running in parallel as messages were printed to screen for each file that was processed rather than for the full results. These changes are aimed at improving this and the percent process indicator has been removed - I may try to reincorporate this in future as I found it quite useful to track progress.

In the course of doing this I noticed that only the output from the first file processed was being written to the csv file and I've tried to fix this.

I have removed the logfile writing function as this is now unused and was previously found to be very slow.

It may be better in future to read the profile list in the main function like is now done for the list of QC checks so that the QC checks can see all the profiles rather than just the ones in the same file as the profile currently being QCed. This might help avoid the need for careful division of the input files for tests like the track check, although it might complicate things in other ways.