### PR TITLE
Fix order of applying the catchFlags function and separate out an aspect of the EN background check

### DIFF
--- a/AutoQC.py
+++ b/AutoQC.py
@@ -41,6 +41,7 @@ def processFile(fName):
     # Check that there are temperature data in the profile, otherwise skip.
     if p.var_index() is None:
       continue
+    main.catchFlags(p)
     if np.sum(p.t().mask == False) == 0:
       continue
     # Run each test.    

--- a/qctest_requirements.json
+++ b/qctest_requirements.json
@@ -5,6 +5,10 @@
     "data":["EN_bgcheck_info.nc"]
   },
   {
+    "applies_to":["EN_background_available_check"],
+    "qctests":["EN_background_check"]
+  },
+  {
     "applies_to":["CoTeDe_*"],
     "modules":["cotede"]
   },

--- a/qctests/EN_background_available_check.py
+++ b/qctests/EN_background_available_check.py
@@ -1,0 +1,58 @@
+""" 
+The background check on reported levels from the EN quality control 
+system, http://www.metoffice.gov.uk/hadobs/en3/OQCpaper.pdf, includes
+setting the QC flags if the background is not available at a profile level.
+This aspect is separated out in this check.
+"""
+
+import numpy as np
+from qctests.EN_background_check import auxParam
+from qctests.EN_background_check import findGridCell
+
+def test(p, *args):
+    """ 
+    Runs the quality control check on profile p and returns a numpy array 
+    of quality control decisions with False where the data value has 
+    passed the check and True where it failed. 
+    """
+
+    # Define an array to hold results.
+    qc = np.zeros(p.n_levels(), dtype=bool)
+    
+    # Find grid cell nearest to the observation.
+    ilon, ilat = findGridCell(p, auxParam['lon'], auxParam['lat'])
+        
+    # Extract the relevant auxiliary data.
+    imonth = p.month() - 1
+    clim = auxParam['clim'][:, ilat, ilon, imonth]
+    depths = auxParam['depth']
+    
+    # Remove missing data points.
+    iOK = (clim.mask == False)
+    if np.count_nonzero(iOK) == 0:
+        qc[:] = True 
+        return qc
+    clim = clim[iOK]
+    depths = depths[iOK]
+    
+    # Find which levels have data.
+    t = p.t()
+    z = p.z()
+    isTemperature = (t.mask==False)
+    isDepth = (z.mask==False)
+    isData = isTemperature & isDepth
+
+    # Loop over levels.
+    for iLevel in range(p.n_levels()):
+        if isData[iLevel] == False: continue
+        
+        # Get the climatology and error variance values at this level.
+        climLevel = np.interp(z[iLevel], depths, clim, right=99999)
+        if climLevel == 99999:
+            qc[iLevel] = True # This could reject some good data if the 
+                              # climatology is incomplete, but also can act as
+                              # a check that the depth of the profile is 
+                              # consistent with the depth of the ocean.
+    
+    return qc
+

--- a/qctests/EN_background_check.py
+++ b/qctests/EN_background_check.py
@@ -57,10 +57,6 @@ def test(p, *args):
         bgevLevel = np.interp(z[iLevel], depths, bgev, right=99999)
         obevLevel = np.interp(z[iLevel], depths, obev, right=99999)
         if climLevel == 99999:
-            qc[iLevel] = True # This could reject some good data if the 
-                              # climatology is incomplete, but also can act as
-                              # a check that the depth of the profile is 
-                              # consistent with the depth of the ocean.
             continue 
         assert bgevLevel > 0, 'Background error variance <= 0'
         assert obevLevel > 0, 'Observation error variance <= 0'

--- a/tests/EN_background_available_check_validation.py
+++ b/tests/EN_background_available_check_validation.py
@@ -1,0 +1,28 @@
+import qctests.EN_background_available_check
+from util import main
+import util.testingProfile
+import numpy
+
+##### EN_background_check ---------------------------------------------------
+
+def test_EN_background_available_check_depth():
+    '''
+    Make sure EN_background_check is flagging depths where the background is not defined.
+    '''
+
+    p = util.testingProfile.fakeProfile([1.8, 1.8, 1.8, 1.8], [0.0, 2.5, 5.0, 5600.0], latitude=55.6, longitude=12.9, date=[1900, 01, 15, 0], probe_type=7) 
+    qc = qctests.EN_background_available_check.test(p)
+    expected = [False, False, False, True]
+    assert numpy.array_equal(qc, expected), 'mismatch between qc results and expected values'
+
+def test_EN_background_available_check_location():
+    '''
+    Make sure EN_background_check is flagging land locations.
+    '''
+
+    p = util.testingProfile.fakeProfile([1.8, 1.8, 1.8, 1.8], [0.0, 2.5, 5.0, 7.5], latitude=0.0, longitude=20.0, date=[1900, 01, 15, 0], probe_type=7) 
+    qc = qctests.EN_background_available_check.test(p)
+    expected = [True, True, True, True]
+    assert numpy.array_equal(qc, expected), 'mismatch between qc results and expected values'
+
+

--- a/util/main.py
+++ b/util/main.py
@@ -46,9 +46,7 @@ def profileData(pinfo, currentFile, f):
     currentFile = pinfo.file_name
     f = open(currentFile)
   if f.tell() != pinfo.file_position: f.seek(pinfo.file_position)
-  profile = wod.WodProfile(f)
-  catchFlags(profile)
-  return profile, currentFile, f
+  return wod.WodProfile(f), currentFile, f
 
 def importQC(dir):
   '''


### PR DESCRIPTION
catchFlags was being applied before the check that there were temperature data in a profile.

Recent results suggested that rejected levels where the EN background is not defined may not be the best approach so this is separated out.