### PR TITLE
Removed install of seabird from the travis config file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ before_install:
 install:
   #- conda install -y -c https://conda.binstar.org/jjhelmus pyproj
   - pip install wodpy
-  - pip install seabird
   - pip install cotede
   - pip install gsw
   - pip install scikit-fuzzy


### PR DESCRIPTION
As discussed in #120, it is not necessary to have the line installing the seabird package in the travis configuration.