### PR TITLE
CSIRO

### DIFF
--- a/qctests/CSIRO_depth.py
+++ b/qctests/CSIRO_depth.py
@@ -12,32 +12,22 @@ def test(p):
     passed the check and True where it failed.
     """
 
-    # Get temperature values from the profile.
-    t = p.t()
     # Get depth values (m) from the profile.
     d = p.z()
     # is this an xbt?
     isXBT = p.probe_type() == 2
 
-    assert len(t.data) == len(d.data), 'Number of temperature measurements does not equal number of depth measurements.'
-
     # initialize qc as a bunch of falses;
-    # implies all measurements pass when a gradient can't be calculated, such as at edges & gaps in data:
     qc = numpy.zeros(len(t.data), dtype=bool)
 
     # check for gaps in data
-    isTemperature = (t.mask==False)
     isDepth = (d.mask==False)
-    isData = isTemperature & isDepth
 
     for i in range(0,len(t.data)-1):
-        if isData[i] & isData[i+1]:
-
-            gradient = (d.data[i+1] - d.data[i]) / (t.data[i+1] - t.data[i]) 
-            print gradient
-            # gradient flag
-            if gradient > -0.4 and gradient < 12.5:
+        if isDepth[i]:
+            # too-shallow temperatures on XBT probes
+            # note we simply flag this profile for manual QC, in order to minimize false negatives.
+            if isXBT and d.data[i] < 3.6:
                 qc[i] = True
 
-    print qc
     return qc

--- a/qctests/CSIRO_depth.py
+++ b/qctests/CSIRO_depth.py
@@ -18,12 +18,12 @@ def test(p):
     isXBT = p.probe_type() == 2
 
     # initialize qc as a bunch of falses;
-    qc = numpy.zeros(len(t.data), dtype=bool)
+    qc = numpy.zeros(p.n_levels(), dtype=bool)
 
     # check for gaps in data
     isDepth = (d.mask==False)
 
-    for i in range(0,len(t.data)-1):
+    for i in range(p.n_levels()):
         if isDepth[i]:
             # too-shallow temperatures on XBT probes
             # note we simply flag this profile for manual QC, in order to minimize false negatives.

--- a/qctests/CSIRO_gradient.py
+++ b/qctests/CSIRO_gradient.py
@@ -34,7 +34,7 @@ def test(p):
         if isData[i] & isData[i+1]:
 
             gradient = (d.data[i+1] - d.data[i]) / (t.data[i+1] - t.data[i]) 
-            print gradient
+            
             # gradient flag
             if gradient > -0.4 and gradient < 12.5:
                 qc[i] = True

--- a/qctests/CSIRO_wire_break.py
+++ b/qctests/CSIRO_wire_break.py
@@ -1,0 +1,32 @@
+"""
+Implements the wire break test of DOI: 10.1175/JTECHO539.1
+All questionable features result in a flag, in order to minimize false negatives 
+"""
+
+import numpy
+
+def test(p):
+    """
+    Runs the quality control check on profile p and returns a numpy array
+    of quality control decisions with False where the data value has
+    passed the check and True where it failed.
+    """
+
+    # Get temperature values from the profile.
+    t = p.t()
+    # is this an xbt?
+    isXBT = p.probe_type() == 2
+
+    # initialize qc as a bunch of falses;
+    qc = numpy.zeros(len(t.data), dtype=bool)
+
+    # check for gaps in data
+    isTemperature = (t.mask==False)
+
+    # wire breaks at bottom of profile:
+    i = len(t.data)-1
+    if isTemperature[i] and isXBT:
+        if t.data[i] < -2.8 or t.data[i] > 36:
+            qc[i] = True
+
+    return qc

--- a/tests/CSIRO_depth_validation.py
+++ b/tests/CSIRO_depth_validation.py
@@ -1,0 +1,32 @@
+import qctests.CSIRO_depth
+import util.testingProfile
+import numpy
+
+##### CSIRO_depth_test ---------------------------------------------------
+
+def test_CSIRO_depth():
+    '''
+    Spot-check the nominal behavior of the CSIRO depth test.
+    '''
+
+    # too shallow for an xbt
+    p = util.testingProfile.fakeProfile([0,0,0], [0,1,20], probe_type=2) 
+    qc = qctests.CSIRO_depth.test(p)
+    truth = numpy.zeros(3, dtype=bool)
+    truth[0] = True
+    truth[1] = True
+    assert numpy.array_equal(qc, truth), 'failed to flag a too-shallow xbt measurement'
+
+    # shallow but not an xbt - don't flag
+    p = util.testingProfile.fakeProfile([0,0,0], [0,1,20], probe_type=1) 
+    qc = qctests.CSIRO_depth.test(p)
+    truth = numpy.zeros(3, dtype=bool)
+    assert numpy.array_equal(qc, truth), 'flagged a non-xbt measurement'    
+
+    # threshold value - don't flag
+    p = util.testingProfile.fakeProfile([0,0,0], [0,3.6,20], probe_type=2) 
+    qc = qctests.CSIRO_depth.test(p)
+    truth = numpy.zeros(3, dtype=bool)
+    truth[0] = True
+    print qc
+    assert numpy.array_equal(qc, truth), "shouldn't flag measurements at threshold"   

--- a/tests/CSIRO_gradient_validation.py
+++ b/tests/CSIRO_gradient_validation.py
@@ -1,0 +1,23 @@
+import qctests.CSIRO_gradient
+import util.testingProfile
+import numpy
+
+##### CSIRO_gradient_test ---------------------------------------------------
+
+def test_CSIRO_gradient():
+    '''
+    Spot-check some values in the CSIRO gradient test.
+    '''
+
+    # pass a marginal positive spike (criteria exactly 9 C):
+    p = util.testingProfile.fakeProfile([0,10,0,0.1,-39.9,-39.1], [10,20,30,40,50,60]) 
+    qc = qctests.CSIRO_gradient.test(p)
+    truth = numpy.zeros(6, dtype=bool)
+    truth[0] = True;  # in range
+    truth[1] = False; # too low
+    truth[2] = False; # too high
+    truth[3] = False; # right on the low margin
+    truth[4] = False; # right on the high margin
+    truth[5] = False; # can't caluclate gradient at endpoint
+
+    assert numpy.array_equal(qc, truth), 'nominal beahvior failure in CSIRO_gradient'

--- a/tests/CSIRO_gradient_validation.py
+++ b/tests/CSIRO_gradient_validation.py
@@ -9,8 +9,7 @@ def test_CSIRO_gradient():
     Spot-check some values in the CSIRO gradient test.
     '''
 
-    # pass a marginal positive spike (criteria exactly 9 C):
-    p = util.testingProfile.fakeProfile([0,10,0,0.1,-39.9,-39.1], [10,20,30,40,50,60]) 
+    p = util.testingProfile.fakeProfile([0,10,0,0.1,-24.9,-24.1], [10,20,30,40,50,60]) 
     qc = qctests.CSIRO_gradient.test(p)
     truth = numpy.zeros(6, dtype=bool)
     truth[0] = True;  # in range

--- a/tests/CSIRO_wire_break_validation.py
+++ b/tests/CSIRO_wire_break_validation.py
@@ -1,0 +1,51 @@
+import qctests.CSIRO_wire_break
+import util.testingProfile
+import numpy
+
+##### CSIRO_wire_break_test ---------------------------------------------------
+
+def test_CSIRO_wire_break():
+    '''
+    Spot-check the nominal behavior of the CSIRO wire break test.
+    '''
+
+    # too cold at the bottom of xbt profile
+    p = util.testingProfile.fakeProfile([0,0,-20], [10,20,30], probe_type=2) 
+    qc = qctests.CSIRO_wire_break.test(p)
+    truth = numpy.zeros(3, dtype=bool)
+    truth[2] = True
+    assert numpy.array_equal(qc, truth), 'failed to flag too-cold temperature at bottom of profile'
+
+    # too hot at bottom of xbt profile
+    p = util.testingProfile.fakeProfile([0,0,100], [10,20,30], probe_type=2) 
+    qc = qctests.CSIRO_wire_break.test(p)
+    truth = numpy.zeros(3, dtype=bool)
+    truth[2] = True
+    assert numpy.array_equal(qc, truth), 'failed to flag too-hot temperature at bottom of profile'
+
+    # right on border - no flag
+    p = util.testingProfile.fakeProfile([0,0,-2.8], [10,20,30], probe_type=2) 
+    qc = qctests.CSIRO_wire_break.test(p)
+    truth = numpy.zeros(3, dtype=bool)
+    truth[2] = False
+    assert numpy.array_equal(qc, truth), 'flagged marginally cold temperature at bottom of profile'
+
+    p = util.testingProfile.fakeProfile([0,0,36], [10,20,30], probe_type=2) 
+    qc = qctests.CSIRO_wire_break.test(p)
+    truth = numpy.zeros(3, dtype=bool)
+    truth[2] = False
+    assert numpy.array_equal(qc, truth), 'flagged marginally hot temperature at bottom of profile'
+
+    # don't flag if not an xbt
+    p = util.testingProfile.fakeProfile([0,0,-100], [10,20,30], probe_type=1) 
+    qc = qctests.CSIRO_wire_break.test(p)
+    truth = numpy.zeros(3, dtype=bool)
+    truth[2] = False
+    assert numpy.array_equal(qc, truth), 'flagged non-xbt profile'
+
+    # don't flag if not at bottom of profile
+    p = util.testingProfile.fakeProfile([0,-100,0], [10,20,30], probe_type=2) 
+    qc = qctests.CSIRO_wire_break.test(p)
+    truth = numpy.zeros(3, dtype=bool)
+    truth[1] = False
+    assert numpy.array_equal(qc, truth), "flagged cold temperature that wasn't at bottom of profile"    


### PR DESCRIPTION
 - breaks `CSIRO_gradient` out into gradient, depth and wire break tests, as requested in #113 
 - adds nominal validation for all these tests as per #114 