### PR TITLE
buddy check tune up

### DIFF
--- a/AutoQC.py
+++ b/AutoQC.py
@@ -1,7 +1,7 @@
 from wodpy import wod
 import glob, time
 import numpy as np
-import sys, os, json
+import sys, os, json, data.ds
 import util.main as main
 import pandas
 
@@ -79,6 +79,7 @@ if len(sys.argv)>2:
   # Identify data files and create a profile list.
   filenames = main.readInput('datafiles.json')
   profiles  = main.extractProfiles(filenames)
+  data.ds.profiles = profiles
   print('\n{} file(s) will be read containing {} profiles'.format(len(filenames), len(profiles)))
 
   # Parallel processing.

--- a/qctests/EN_std_lev_bkg_and_buddy_check.py
+++ b/qctests/EN_std_lev_bkg_and_buddy_check.py
@@ -116,12 +116,15 @@ def buddyCovariance(meso_ev_a, meso_ev_b, syn_ev_a, syn_ev_b):
     meso_ev_a == mesoscale error variance for profile a, etc.
     '''
 
-    corScaleA = 300.0 # In km.             
+    corScaleA = 100.0 # In km.             
     corScaleB = 400.0 # In km.
-    corScaleT = 21600.0 # In secs.
+    corScaleT = 432000.0 # In secs.
     mesSDist  = minDist / (1000.0 * corScaleA)
     synSDist  = minDist / (1000.0 * corScaleB)
     timeDiff2 = (timeDiff(profile, buddyProfile) / corScaleT)**2 
+
+    if timeDiff2 is None:
+        return None
 
     covar = (meso_ev_a * meso_ev_b *
             (1.0 + mesSDist) * np.exp(-mesSDist - timeDiff2) + 
@@ -145,6 +148,8 @@ def determine_pgeData(pgeData, pgeBuddy, levels, levelsBuddy, minDist, profile, 
         # later.
 
         covar = buddyCovariance(np.sqrt(bgev[iLevel]), np.sqrt(bgevBuddy[iLevel]), np.sqrt(bgev[iLevel]), np.sqrt(bgevBuddy[iLevel]))
+        if covar is None:
+            return []
 
         errVarA = obev[iLevel] + 2.0 * bgev[iLevel]
         errVarB = obev[iLevel] + 2.0 * bgevBuddy[iLevel]
@@ -262,7 +267,8 @@ def timeDiff(p1, p2):
         year  = prof.year()
         month = prof.month()
         day   = prof.day()
-        if day == 0: day = 15
+        if not (year > 0) or not (1 <= month <= 12) or not (1 <= day <= 31):
+            return None 
         time  = prof.time()
         if time is None or time < 0 or time >= 24:
             hours   = 0

--- a/qctests/EN_std_lev_bkg_and_buddy_check.py
+++ b/qctests/EN_std_lev_bkg_and_buddy_check.py
@@ -13,7 +13,7 @@ import EN_range_check
 import EN_spike_and_step_check
 import EN_stability_check
 import util.main as main
-import __main__
+import data.ds
 import numpy as np
 
 def test(p):
@@ -40,7 +40,7 @@ def test(p):
     pgeData = determine_pge(levels, bgev, obev, p)
 
     # Find buddy.
-    profiles = __main__.profiles
+    profiles = data.ds.profiles
     minDist  = 1000000000.0
     iMinDist = None
     for iProfile, profile in enumerate(profiles):
@@ -195,29 +195,6 @@ def stdLevelData(p):
     nLevels, origLevels, diffLevels = filterLevels(preQC, origLevels, diffLevels)
     if nLevels == 0: return None
     
-    # # Get the set of standard levels.
-    # stdLevels = EN_background_check.auxParam['depth']
-    
-    # # Create arrays to hold the standard level data and aggregate.
-    # nStdLevels = len(stdLevels)
-    # levels     = np.zeros(nStdLevels)
-    # nPerLev    = np.zeros(nStdLevels) 
-    # z          = p.z()
-    # assocLevs  = []
-    # for i, origLevel in enumerate(origLevels):
-    #     # Find the closest standard level.
-    #     j          = np.argmin(np.abs(z[origLevel] - stdLevels))
-    #     assocLevs.append(j)
-    #     levels[j]  += diffLevels[i]
-    #     nPerLev[j] += 1
-
-    # # Average the standard levels where there are data.
-    # iGT1 = nPerLev > 1
-    # levels[iGT1] /= nPerLev[iGT1]
-    # levels = np.ma.array(levels)
-    # levels.mask = False
-    # levels.mask[nPerLev == 0] = True
-
     levels, assocLevs = meanDifferencesAtStandardLevels(origLevels, diffLevels, p.z())
 
     return levels, origLevels, assocLevs

--- a/tests/EN_std_level_background_check_validation.py
+++ b/tests/EN_std_level_background_check_validation.py
@@ -1,10 +1,11 @@
 import qctests.EN_std_lev_bkg_and_buddy_check
+import qctests.EN_background_check
 from util import main
 import util.testingProfile
 import numpy
 import __main__
 
-##### EN_background_check ---------------------------------------------------
+##### EN_std_lev_bkg_and_buddy_check ---------------------------------------------------
 
 def test_EN_std_level_bkg_and_buddy_check_temperature():
     '''
@@ -18,4 +19,26 @@ def test_EN_std_level_bkg_and_buddy_check_temperature():
     print qc
     assert numpy.array_equal(qc, expected), 'mismatch between qc results and expected values'
 
+def test_determine_pge():
+    '''
+    totally ridiculous differences between observation and background should give pge == 1
+    '''
 
+    p = util.testingProfile.fakeProfile([1.8, 1.8, 1.8, 7.1], [0.0, 2.5, 5.0, 7.5], latitude=55.6, longitude=12.9, date=[1900, 01, 15, 0], probe_type=7) 
+    levels = numpy.ma.array([1000,1000,1000,1000])
+    levels.mask = False
+    bgev = qctests.EN_background_check.bgevStdLevels
+    obev = qctests.EN_background_check.auxParam['obev']
+    expected = [1.0, 1.0, 1.0, 1.0]
+    assert numpy.array_equal(qctests.EN_std_lev_bkg_and_buddy_check.determine_pge(levels, bgev, obev, p), expected), 'PGE of extreme departures from background not flagged as 1.0'
+
+def test_timeDiff():
+    '''
+    standard behavior of time difference calculator
+    '''
+
+    p1 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], date=[1900, 1, 1, 12])
+    p2 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], date=[1900, 1, 1, 13])
+
+    assert qctests.EN_std_lev_bkg_and_buddy_check.timeDiff(p1, p2) == 3600, 'incorrect time difference reported'
+    assert qctests.EN_std_lev_bkg_and_buddy_check.timeDiff(p2, p1) == 3600, 'time differences should always be positive'

--- a/tests/EN_std_level_background_check_validation.py
+++ b/tests/EN_std_level_background_check_validation.py
@@ -102,7 +102,29 @@ def test_buddyCovariance_time():
     p2 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], date=[1900, 1, 11, 12])
     buddyCovariance_10days = qctests.EN_std_lev_bkg_and_buddy_check.buddyCovariance(100, p1, p2, 1, 1, 1, 1)    
 
-    assert buddyCovariance_5days * numpy.exp(-3) == buddyCovariance_10days, 'incorrect timescale behavior'
+    assert buddyCovariance_5days * numpy.exp(-3) - buddyCovariance_10days < 1e-12, 'incorrect timescale behavior'
 
+def test_buddyCovariance_mesoscale():
+    '''
+    make sure buddyCovariance displays the correct behavior in mesoscale correlation.
+    '''
 
+    p1 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], date=[1900, 1, 1, 12])
+    p2 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], date=[1900, 1, 6, 12])
+    buddyCovariance_100km = qctests.EN_std_lev_bkg_and_buddy_check.buddyCovariance(100000, p1, p2, 1, 1, 0, 0)
+    buddyCovariance_200km = qctests.EN_std_lev_bkg_and_buddy_check.buddyCovariance(200000, p1, p2, 1, 1, 0, 0)
+  
 
+    assert buddyCovariance_100km * numpy.exp(-1) - buddyCovariance_200km < 1e-12, 'incorrect mesoscale correlation'
+
+def test_buddyCovariance_synoptic_scale():
+    '''
+    make sure buddyCovariance displays the correct behavior in synoptic scale correlation.
+    '''
+
+    p1 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], date=[1900, 1, 1, 12])
+    p2 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], date=[1900, 1, 6, 12])
+    buddyCovariance_100km = qctests.EN_std_lev_bkg_and_buddy_check.buddyCovariance(100000, p1, p2, 0, 0, 1, 1)
+    buddyCovariance_500km = qctests.EN_std_lev_bkg_and_buddy_check.buddyCovariance(500000, p1, p2, 0, 0, 1, 1)
+  
+    assert buddyCovariance_100km * numpy.exp(-1) - buddyCovariance_500km < 1e-12, 'incorrect synoptic scale correlation'

--- a/tests/EN_std_level_background_check_validation.py
+++ b/tests/EN_std_level_background_check_validation.py
@@ -88,13 +88,35 @@ def test_filterLevels():
     '''
 
     preQC = [True, False, True, True, False]
-    origLevels = numpy.array([1,2,3,4,5])
-    diffLevels = numpy.array([9,8,7,6,0])
+    origLevels = numpy.array([0,2,3,4])
+    diffLevels = numpy.array([10,11,12,13])
 
     nLevels, origLevels, diffLevels = qctests.EN_std_lev_bkg_and_buddy_check.filterLevels(preQC, origLevels, diffLevels)
 
-    assert numpy.array_equal(origLevels, [2,5])
-    assert numpy.array_equal(diffLevels, [8,0])
+    assert numpy.array_equal(origLevels, [4])
+    assert numpy.array_equal(diffLevels, [13])
+
+def test_meanDifferencesAtStandardLevels():
+    '''
+    check a simple case for calculating mean level differences.
+    '''
+
+    stdLevels = qctests.EN_background_check.auxParam['depth']
+
+    origLevels = [0,2,3]
+    diffLevels = [3,5,7]
+    depths = [5, 5.1, 45, 46]
+
+    levels, assocLevs = qctests.EN_std_lev_bkg_and_buddy_check.meanDifferencesAtStandardLevels(origLevels, diffLevels, depths)
+
+    trueLevels = numpy.zeros(len(stdLevels))
+    trueLevels[0] = 3 # level 0 alone
+    trueLevels[4] = 6 # level 2 and 3 averaged
+    trueLevels = numpy.ma.array(trueLevels)
+    trueLevels.mask = False
+
+    assert numpy.array_equal(levels, trueLevels)
+    assert numpy.array_equal(assocLevs, [0,4,4]) # since 5 ~ first standard level, 5.1 isn't considered, and 45 and 46 are ~ 5th std. level.
 
 def test_assessBuddyDistance_invalid_buddies():
     '''

--- a/tests/EN_std_level_background_check_validation.py
+++ b/tests/EN_std_level_background_check_validation.py
@@ -1,5 +1,6 @@
 import qctests.EN_std_lev_bkg_and_buddy_check
 import qctests.EN_background_check
+from cotede.qctests.possible_speed import haversine
 from util import main
 import util.testingProfile
 import numpy
@@ -42,3 +43,56 @@ def test_timeDiff():
 
     assert qctests.EN_std_lev_bkg_and_buddy_check.timeDiff(p1, p2) == 3600, 'incorrect time difference reported'
     assert qctests.EN_std_lev_bkg_and_buddy_check.timeDiff(p2, p1) == 3600, 'time differences should always be positive'
+
+def test_timeDiff_garbage_time():
+    '''
+    timeDiff returns none when it finds garbage times
+    '''
+
+    p1 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], date=[1900, -1, 1, 12])
+    p2 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], date=[1900, 1, 1, 13])
+
+    assert qctests.EN_std_lev_bkg_and_buddy_check.timeDiff(p1, p2) is None, 'failed to reurn None when a nonsesne date was found'
+
+def test_assessBuddyDistance_invalid_buddies():
+    '''
+    check buddy distance rejects invalid buddy pairs
+    '''
+
+    p1 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], 0, 0, date=[1900, 1, 1, 12], uid=0, cruise=1)
+    p2 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], 0, 0, date=[1900, 1, 1, 13], uid=0, cruise=2)
+    assert qctests.EN_std_lev_bkg_and_buddy_check.assessBuddyDistance(p1, p2) is None, 'accepted buddies with same uid'
+
+    p1 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], 0, 0, date=[1900, 1, 1, 12], uid=0, cruise=1)
+    p2 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], date=[1901, 1, 1, 13], uid=1, cruise=2)
+    assert qctests.EN_std_lev_bkg_and_buddy_check.assessBuddyDistance(p1, p2) is None, 'accepted buddies with different year'
+
+    p1 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], 0, 0, date=[1900, 1, 1, 12], uid=0, cruise=1)
+    p2 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], 0, 0, date=[1900, 2, 1, 13], uid=1, cruise=2)
+    assert qctests.EN_std_lev_bkg_and_buddy_check.assessBuddyDistance(p1, p2) is None, 'accepted buddies with different month'
+
+    p1 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], 0, 0, date=[1900, 1, 1, 12], uid=0, cruise=1)
+    p2 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], 0, 0, date=[1900, 1, 1, 13], uid=1, cruise=1)
+    assert qctests.EN_std_lev_bkg_and_buddy_check.assessBuddyDistance(p1, p2) is None, 'accepted buddies with same cruise'
+
+    p1 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], 0, 0, date=[1900, 1, 1, 12], uid=0, cruise=1)
+    p2 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], 5.01, 0, date=[1900, 1, 1, 13], uid=1, cruise=2)
+    assert qctests.EN_std_lev_bkg_and_buddy_check.assessBuddyDistance(p1, p2) is None, 'accepted buddies too far apart in latitude'
+
+def test_assessBuddyDistance_haversine():
+    '''
+    make sure haversine calculation is consistent with rest of package
+    '''
+
+    p1 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], 0, 0, date=[1900, 1, 1, 12], uid=0, cruise=1)
+    p2 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], 1, 1, date=[1900, 1, 1, 13], uid=1, cruise=2)
+    assert qctests.EN_std_lev_bkg_and_buddy_check.assessBuddyDistance(p1, p2) == haversine(0,0,1,1), 'haversine calculation inconsistent with cotede.qctests.possible_speed.haversine'
+
+
+
+
+
+
+
+
+

--- a/tests/EN_std_level_background_check_validation.py
+++ b/tests/EN_std_level_background_check_validation.py
@@ -4,7 +4,7 @@ from cotede.qctests.possible_speed import haversine
 from util import main
 import util.testingProfile
 import numpy
-import __main__
+import data.ds
 
 ##### EN_std_lev_bkg_and_buddy_check ---------------------------------------------------
 
@@ -14,7 +14,7 @@ def test_EN_std_level_bkg_and_buddy_check_temperature():
     '''
 
     p = util.testingProfile.fakeProfile([1.8, 1.8, 1.8, 7.1], [0.0, 2.5, 5.0, 7.5], latitude=55.6, longitude=12.9, date=[1900, 01, 15, 0], probe_type=7) 
-    __main__.profiles = [p]
+    data.ds.profiles = [p]
     qc = qctests.EN_std_lev_bkg_and_buddy_check.test(p)
     expected = [False, False, False, False]
     print qc

--- a/tests/EN_std_level_background_check_validation.py
+++ b/tests/EN_std_level_background_check_validation.py
@@ -89,10 +89,20 @@ def test_assessBuddyDistance_haversine():
     assert qctests.EN_std_lev_bkg_and_buddy_check.assessBuddyDistance(p1, p2) == haversine(0,0,1,1), 'haversine calculation inconsistent with cotede.qctests.possible_speed.haversine'
 
 
+def test_buddyCovariance_time():
+    '''
+    make sure buddyCovariance displays the correct behavior in time.
+    '''
 
+    p1 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], date=[1900, 1, 1, 12])
+    p2 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], date=[1900, 1, 6, 12])
+    buddyCovariance_5days = qctests.EN_std_lev_bkg_and_buddy_check.buddyCovariance(100, p1, p2, 1, 1, 1, 1)
 
+    p1 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], date=[1900, 1, 1, 12])
+    p2 = util.testingProfile.fakeProfile([0,0,0],[0,0,0], date=[1900, 1, 11, 12])
+    buddyCovariance_10days = qctests.EN_std_lev_bkg_and_buddy_check.buddyCovariance(100, p1, p2, 1, 1, 1, 1)    
 
-
+    assert buddyCovariance_5days * numpy.exp(-3) == buddyCovariance_10days, 'incorrect timescale behavior'
 
 
 

--- a/util/testingProfile.py
+++ b/util/testingProfile.py
@@ -6,7 +6,7 @@ class fakeProfile:
     implementations of qc-tests.
     '''
 
-    def __init__(self, temperatures, depths, latitude=None, longitude=None, date=[1999, 12, 31, 0], probe_type=None, salinities=None, pressures=None, uid=None):
+    def __init__(self, temperatures, depths, latitude=None, longitude=None, date=[1999, 12, 31, 0], probe_type=None, salinities=None, pressures=None, uid=None, cruise=None):
         self.temperatures = temperatures
         if salinities is None:
             self.salinities = np.ma.array(temperatures, mask=True)
@@ -27,6 +27,7 @@ class fakeProfile:
         self.primary_header['Day'] = date[2]
         self.primary_header['Time'] = date[3]
         self.primary_header['WOD unique cast number'] = uid
+        self.primary_header['Cruise number'] = cruise
         
         self.secondary_header = {'entries':[]}
         if probe_type is not None:
@@ -45,6 +46,10 @@ class fakeProfile:
     def uid(self):
         """ Returns the unique identifier of the profile. """
         return self.primary_header['WOD unique cast number']
+
+    def cruise(self):
+        """ return the cruise number """
+        return self.primary_header['Cruise number']
 
     def t(self):
         """ Returns a numpy masked array of temperatures. """


### PR DESCRIPTION
This PR will contain several updates to the buddy check and related infrastructure, per discussion in #133. Todo:

 - ~~Slice up buddy check into shorter helper functions~~
 - ~~Test buddy check helpers~~
 - Persist all qc results for `EN` tests to avoid rerunning
 - ~~Address some small issues with the buddy check:~~
  - ~~use the datastore module for passing global variables, rather than importing `__main__`~~
  - ~~currently throws a complaint:~~
```
/opt/conda/lib/python2.7/site-packages/numpy/ma/core.py:4089: UserWarning: Warning: converting a masked element to nan.
  warnings.warn("Warning: converting a masked element to nan.")
```
~~which seems ominous - should be addressed.~~

Before tackling upgrades like using the datastore and persisting qc, the first two bullets need to get done to ensure those upgrades aren't quietly mangling anything.