### PR TITLE
FIx running in parallel and temporary datetime fix

### DIFF
--- a/AutoQC.py
+++ b/AutoQC.py
@@ -34,6 +34,8 @@ def processFile(fName):
   currentFile  = ''
   f = None
   for iprofile, pinfo in enumerate(profiles):
+    # Do not process data twice if run in parallel.
+    if pinfo.file_name != fName: continue 
     # Load the profile data.
     p, currentFile, f = main.profileData(pinfo, currentFile, f)
     # Check that there are temperature data in the profile, otherwise skip.

--- a/cotede_qc/cotede_test.py
+++ b/cotede_qc/cotede_test.py
@@ -60,7 +60,7 @@ class DummyCNV(object):
             hours = int(time)
             minutesf = (time - hours) * 60
             minutes  = int(minutesf)
-            seconds  = int(round((minutesf - minutes) * 60))
+            seconds  = min(int(round((minutesf - minutes) * 60)), 59)
 
         self.attributes['datetime'] = datetime.datetime(year, month, day, hours, minutes, seconds)
 


### PR DESCRIPTION
This pull request has two fixes:

1. I realised that now that the list of profiles is read in the main program, when running in parallel each process will attempt to QC the whole set of profiles. I've introduced a fix for this, although it is possibly not the most elegant solution!

2. A temporary fix to prevent 60 seconds being passed to datetime. This is just so that the processing will run until a more permanent fix is implemented.