### PR TITLE
Climatology test with WOA13

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Docker makes it very convenient for the project to run AutoQC, but note that the
  - temperature_seasonal_5deg.nc (https://www.nodc.noaa.gov/OC5/indprod.html) from http://data.nodc.noaa.gov/thredds/fileServer/woa/WOA09/NetCDFdata/temperature_seasonal_5deg.nc;
  - etopo5.nc (http://www.ngdc.noaa.gov/mgg/global/etopo5.HTML) from http://oos.soest.hawaii.edu/thredds/ncss/etopo5?var=ROSE&disableLLSubset=on&disableProjSubset=on&horizStride=1&addLatLon=true;
  - climatological_t_median_and_amd_for_aqc.nc: based on climatological_t_median_and_amd_for_aqc.dat provided by Viktor Gouretski, Integrated Climate Data Center, University of Hamburg, Hamburg, Germany, February 2016.
+ - Seasonal WOA13 files (http://data.nodc.noaa.gov/thredds/fileServer/woa/WOA13/DATAv2/temperature/netcdf/decav/5deg/):
+   - woa13_decav_t13_5dv2.nc
+   - woa13_decav_t14_5dv2.nc
+   - woa13_decav_t15_5dv2.nc
+   - woa13_decav_t16_5dv2.nc
 
 ### AutoQC on AWS
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,10 @@ RUN pip install wodpy cotede==0.15.3 gsw scikit-fuzzy pyWOA
 RUN git clone https://github.com/IQuOD/AutoQC.git
 ADD EN_bgcheck_info.nc /AutoQC/data/.
 ADD temperature_seasonal_5deg.nc /AutoQC/data/.
+ADD woa13_decav_s13_5dv2.nc /AutoQC/data/.
+ADD woa13_decav_s14_5dv2.nc /AutoQC/data/.
+ADD woa13_decav_s15_5dv2.nc /AutoQC/data/.
+ADD woa13_decav_s16_5dv2.nc /AutoQC/data/.
 ADD etopo5.nc /AutoQC/data/.
 ADD climatological_t_median_and_amd_for_aqc.nc /AutoQC/data/.
 


### PR DESCRIPTION
The climatology test at CoTeDe was updated to WOA13. If not available, the required files are automatically downloaded, but if we include those into the docker it could save quite some time, and bandwidth.

Would that be fine to include those files with the docker?