### PR TITLE
Optimize CoTeDe

### DIFF
--- a/cotede_qc/cotede_test.py
+++ b/cotede_qc/cotede_test.py
@@ -102,11 +102,7 @@ def get_qc(p, config, test):
                           config, 
                           ProfileQC(inputs, cfg=cfg)]
     
-    # Define where the QC results are found.
-    if test == 'location_at_sea':
-        var = 'common'
-    else:
-        var = 'TEMP'
+    var = 'TEMP'
 
     # Get the QC results, which use the IOC conventions.
     qc_returned = cotede_results[2].flags[var][test]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,10 @@ RUN apt-get update
 # dependencies!
 RUN apt-get -y install libhdf5-serial-dev libnetcdf-dev unzip
 RUN conda install --yes python=2.7 pip nose Shapely netCDF4 matplotlib numpy scipy pyproj pandas
-RUN pip install wodpy cotede==0.15.3 gsw scikit-fuzzy pyWOA
+#RUN pip install wodpy>=1.3.0 cotede>=0.15.4 gsw scikit-fuzzy pyWOA>=0.1.2
+RUN pip install wodpy cotede gsw scikit-fuzzy pyWOA
+# Temporary solution while pypi doesn't fix its index.
+RUN pip install --upgrade wodpy cotede pyWOA
 
 # fetch & setup AutoQC + data
 RUN git clone https://github.com/IQuOD/AutoQC.git


### PR DESCRIPTION
pypi is having problems with its indexes, so an alternative to keep the packages updated might be to `pip install --upgrade` when generating the docker.

If that works, the common flags at CoTeDe will not be required anymore.