### PR TITLE
Fixes for runtime errors when running EN track check.

### DIFF
--- a/AutoQC.py
+++ b/AutoQC.py
@@ -36,6 +36,7 @@ def processFile(fName):
 
   # keep a list of only the profiles in this thread
   data.ds.threadProfiles = main.extractProfiles([fName])
+  data.ds.threadFile     = fName
 
   for iprofile, pinfo in enumerate(data.ds.threadProfiles):
     # Load the profile data.

--- a/qctests/EN_track_check.py
+++ b/qctests/EN_track_check.py
@@ -17,6 +17,7 @@ TimeRes = 600. # seconds
 
 EN_track_headers = {}
 EN_track_results = {}
+threadFile       = {}
 
 def test(p):
     """ 
@@ -27,6 +28,7 @@ def test(p):
 
     global EN_track_headers
     global EN_track_results
+    global threadFile
 
     cruise = p.cruise()
     uid = p.uid()
@@ -50,8 +52,9 @@ def test(p):
         return np.zeros(1, dtype=bool)
 
     # the first time this test is run, sort ds.threadProfiles into a cruise-keyed dictionary:
-    if EN_track_headers == {}:
+    if ds.threadFile != threadFile:
         EN_track_headers = main.sort_headers(ds.threadProfiles)
+        threadFile = ds.threadFile
 
     # since we didn't find an answer already calculated,
     # we still need to do the calculation for this cruise;

--- a/tests/EN_track_validation.py
+++ b/tests/EN_track_validation.py
@@ -14,10 +14,14 @@ class TestClass():
     def setUp(self):
         qctests.EN_track_check.EN_track_results = {}
         qctests.EN_track_check.EN_track_headers = {}
+        qctests.EN_track_check.threadFile       = ''
+        ds.threadFile                           = 'test'
 
     def tearDown(self):
         del qctests.EN_track_check.EN_track_results
         del qctests.EN_track_check.EN_track_headers
+        del qctests.EN_track_check.threadFile
+        del ds.threadFile
 
     def trackSpeed_test(self):
         '''

--- a/util/geo.py
+++ b/util/geo.py
@@ -84,8 +84,11 @@ def deltaTime(earlier, later):
     eHour, eMinute, eSecond = parseTime(earlier.time())
     lHour, lMinute, lSecond = parseTime(later.time())
 
-    early = datetime(year=earlier.year(), month=earlier.month(), day=earlier.day(), hour=eHour, minute=eMinute, second=eSecond )
-    late = datetime(year=later.year(), month=later.month(), day=later.day(), hour=lHour, minute=lMinute, second=lSecond )
+    try:
+        early = datetime(year=earlier.year(), month=earlier.month(), day=earlier.day(), hour=eHour, minute=eMinute, second=eSecond )
+        late = datetime(year=later.year(), month=later.month(), day=later.day(), hour=lHour, minute=lMinute, second=lSecond )
+    except:
+        return None
 
     timeDiff = (late - early).total_seconds()
     assert timeDiff >= 0, 'early date %s is after later date %s' % (early, late)


### PR DESCRIPTION
This pull request fixes a couple of issues I found when running the EN track check on the full QuOTA dataset:

- util/geo.py needs to handle missing data when creating datetime instances.
- The test crashes if number of data files > number of threads because the EN_track_headers variable is not {} after the first file is processed in the thread. I've attempted to fix this by saving the data file name and updating EN_track_headers when this changes.