### PR TITLE
Change Argo tests to work on pressure instead of depth.

### DIFF
--- a/qctests/Argo_global_range_check.py
+++ b/qctests/Argo_global_range_check.py
@@ -5,6 +5,8 @@ system.
 See Argo quality control manual (based on version 2.5).
 """
 
+from util import obs_utils
+
 def test(p):
     """ 
     Runs the quality control check on profile p and returns a numpy array 
@@ -14,7 +16,7 @@ def test(p):
 
     # Get temperature and pressure values from the profile.
     t = p.t()
-    z = p.z()
+    z = obs_utils.depth_to_pressure(p.z(), p.latitude())
 
     # Make the quality control decisions. This should
     # return true if the temperature is outside -2.5 deg C

--- a/qctests/Argo_gradient_test.py
+++ b/qctests/Argo_gradient_test.py
@@ -3,6 +3,7 @@ Implements the gradient test on page 8 of http://w3.jcommops.org/FTPRoot/Argo/Do
 """
 
 import numpy
+from util import obs_utils
 
 def test(p):
     """
@@ -14,9 +15,9 @@ def test(p):
     # Get temperature values from the profile.
     t = p.t()
     # Get depth values (m) from the profile.
-    d = p.z()
+    z = obs_utils.depth_to_pressure(p.z(), p.latitude())
 
-    assert len(t.data) == len(d.data), 'Number of temperature measurements does not equal number of depth measurements.'
+    assert len(t.data) == len(z.data), 'Number of temperature measurements does not equal number of depth measurements.'
 
     # initialize qc as a bunch of falses;
     # implies all measurements pass when a gradient can't be calculated, such as at edges & gaps in data:
@@ -24,15 +25,15 @@ def test(p):
 
     # check for gaps in data
     isTemperature = (t.mask==False)
-    isDepth = (d.mask==False)
-    isData = isTemperature & isDepth
+    isPressure = (z.mask==False)
+    isData = isTemperature & isPressure
 
     for i in range(1,len(t.data)-1):
         if isData[i] & isTemperature[i-1] & isTemperature[i+1]:
 
           isSlope = numpy.abs(t.data[i] - (t.data[i-1] + t.data[i+1])/2)
 
-          if d.data[i] < 500:
+          if z.data[i] < 500:
               qc[i] = isSlope > 9.0
           else:
               qc[i] = isSlope > 3.0

--- a/qctests/Argo_pressure_increasing_test.py
+++ b/qctests/Argo_pressure_increasing_test.py
@@ -7,6 +7,7 @@ http://w3.jcommops.org/FTPRoot/Argo/Doc/argo-quality-control-manual.pdf page 8.
 """
 
 import numpy as np
+from util import obs_utils
 
 def test(p):
     """ 
@@ -16,7 +17,7 @@ def test(p):
     """
 
     # Get vertical coordinate values from the profile.
-    z = p.z()
+    z = obs_utils.depth_to_pressure(p.z(), p.latitude())
 
     # Make the quality control decisions. This should
     # return true where z decreases or stays the same.

--- a/qctests/Argo_spike_test.py
+++ b/qctests/Argo_spike_test.py
@@ -3,6 +3,7 @@ Implements the spike test on page 8 of http://w3.jcommops.org/FTPRoot/Argo/Doc/a
 """
 
 import numpy
+from util import obs_utils
 
 def test(p):
     """
@@ -13,10 +14,10 @@ def test(p):
 
     # Get temperature values from the profile.
     t = p.t()
-    # Get depth values (m) from the profile.
-    d = p.z()
+    # Get pressure values (db) from the profile.
+    z = obs_utils.depth_to_pressure(p.z(), p.latitude())
 
-    assert len(t.data) == len(d.data), 'Number of temperature measurements does not equal number of depth measurements.'
+    assert len(t.data) == len(z.data), 'Number of temperature measurements does not equal number of depth measurements.'
 
     # initialize qc as a bunch of falses;
     # implies all measurements pass when a spike can't be calculated, such as at edges & gaps in data:
@@ -24,14 +25,14 @@ def test(p):
 
     # check for gaps in data
     isTemperature = (t.mask==False)
-    isDepth = (d.mask==False)
-    isData = isTemperature & isDepth
+    isPressure = (z.mask==False)
+    isData = isTemperature & isPressure
 
     for i in range(1,len(t.data)-1):
         if isData[i] & isTemperature[i-1] & isTemperature[i+1]:
 
           isSpike = numpy.abs(t.data[i] - (t.data[i-1] + t.data[i+1])/2) - numpy.abs((t.data[i+1] - t.data[i-1])/2)
-          if d.data[i] < 500:
+          if z.data[i] < 500:
               qc[i] = isSpike > 6.0
           else:
               qc[i] = isSpike > 2.0

--- a/tests/Argo_global_range_check_validation.py
+++ b/tests/Argo_global_range_check_validation.py
@@ -1,6 +1,7 @@
 import qctests.Argo_global_range_check
 import util.testingProfile
 import numpy
+from util import obs_utils
 
 ##### Argo_global_range_check ---------------------------------------------------
 
@@ -10,26 +11,26 @@ def test_Argo_global_range_check_temperature():
     '''
 
     # should fail despite rounding
-    p = util.testingProfile.fakeProfile([-2.500000001], [100]) 
+    p = util.testingProfile.fakeProfile([-2.500000001], [100], latitude=0.0) 
     qc = qctests.Argo_global_range_check.test(p)
     truth = numpy.zeros(1, dtype=bool)
     truth[0] = True
     assert numpy.array_equal(qc, truth), 'failed to flag temperature slightly colder than -2.5 C'
 
     # -2.5 OK
-    p = util.testingProfile.fakeProfile([-2.5], [100]) 
+    p = util.testingProfile.fakeProfile([-2.5], [100], latitude=0.0) 
     qc = qctests.Argo_global_range_check.test(p)
     truth = numpy.zeros(1, dtype=bool)
     assert numpy.array_equal(qc, truth), 'incorrectly flagging -2.5 C'
 
     # 40 OK
-    p = util.testingProfile.fakeProfile([40], [100]) 
+    p = util.testingProfile.fakeProfile([40], [100], latitude=0.0) 
     qc = qctests.Argo_global_range_check.test(p)
     truth = numpy.zeros(1, dtype=bool)
     assert numpy.array_equal(qc, truth), 'incorrectly flagging 40 C'
 
     # should fail despite rounding
-    p = util.testingProfile.fakeProfile([40.0000001], [100]) 
+    p = util.testingProfile.fakeProfile([40.0000001], [100], latitude=0.0) 
     qc = qctests.Argo_global_range_check.test(p)
     truth = numpy.zeros(1, dtype=bool)
     truth[0] = True
@@ -41,14 +42,14 @@ def test_Argo_global_range_check_pressure():
     '''
 
     # should fail despite rounding
-    p = util.testingProfile.fakeProfile([5], [-5.00000001]) 
+    p = util.testingProfile.fakeProfile([5], obs_utils.pressure_to_depth([-5.00000001], 0.0), latitude=0.0) 
     qc = qctests.Argo_global_range_check.test(p)
     truth = numpy.zeros(1, dtype=bool)
     truth[0] = True
     assert numpy.array_equal(qc, truth), 'failed to flag pressure slightly below -5 '
 
     # -5 OK
-    p = util.testingProfile.fakeProfile([5], [-5]) 
+    p = util.testingProfile.fakeProfile([5], obs_utils.pressure_to_depth([-5], 0.0), latitude=0.0) 
     qc = qctests.Argo_global_range_check.test(p)
     truth = numpy.zeros(1, dtype=bool)
     assert numpy.array_equal(qc, truth), 'incorrectly flagging pressure of -5'

--- a/tests/Argo_gradient_test_validation.py
+++ b/tests/Argo_gradient_test_validation.py
@@ -4,6 +4,8 @@ import numpy
 
 ##### Argo_gradient_test ---------------------------------------------------
 
+from util import obs_utils
+
 def test_Argo_gradient_test_temperature_shallow():
     '''
     Make sure AGT is flagging postive and negative temperature spikes at shallow depths
@@ -14,26 +16,26 @@ def test_Argo_gradient_test_temperature_shallow():
     ###
 
     # pass a marginal positive spike (criteria exactly 9 C):
-    p = util.testingProfile.fakeProfile([2,11,2], [100,200,300]) 
+    p = util.testingProfile.fakeProfile([2,11,2], [100,200,300], latitude=0.0) 
     qc = qctests.Argo_gradient_test.test(p)
     truth = numpy.zeros(3, dtype=bool)
     assert numpy.array_equal(qc, truth), 'incorrectly flagging a positive spike exactly at threshold (shallow).'    
 
     # pass a marginal negative spike (criteria exactly 9 C):
-    p = util.testingProfile.fakeProfile([2,-7,2], [100,200,300]) 
+    p = util.testingProfile.fakeProfile([2,-7,2], [100,200,300], latitude=0.0) 
     qc = qctests.Argo_gradient_test.test(p)
     truth = numpy.zeros(3, dtype=bool)
     assert numpy.array_equal(qc, truth), 'incorrectly flagging a negative spike exactly at threshold (shallow).' 
 
     # fail a marginal positive spike (criteria > 9 C):
-    p = util.testingProfile.fakeProfile([2,11.0001,2], [100,200,300]) 
+    p = util.testingProfile.fakeProfile([2,11.0001,2], [100,200,300], latitude=0.0) 
     qc = qctests.Argo_gradient_test.test(p)
     truth = numpy.zeros(3, dtype=bool)
     truth[1] = True 
     assert numpy.array_equal(qc, truth), 'failing to flag a positive spike just above threshold (shallow).'    
 
     # fail a marginal negative spike (criteria > 9 C):
-    p = util.testingProfile.fakeProfile([2,-7.0001,2], [100,200,300]) 
+    p = util.testingProfile.fakeProfile([2,-7.0001,2], [100,200,300], latitude=0.0) 
     qc = qctests.Argo_gradient_test.test(p)
     truth = numpy.zeros(3, dtype=bool)
     truth[1] = True
@@ -49,45 +51,45 @@ def test_Argo_gradient_test_temperature_deep():
     ###
 
     # pass a marginal positive spike (criteria exactly 9 C):
-    p = util.testingProfile.fakeProfile([2,5,2], [1000,2000,3000]) 
+    p = util.testingProfile.fakeProfile([2,5,2], [1000,2000,3000], latitude=0.0) 
     qc = qctests.Argo_gradient_test.test(p)
     truth = numpy.zeros(3, dtype=bool)
     assert numpy.array_equal(qc, truth), 'incorrectly flagging a positive spike exactly at threshold. (deep)'    
 
     # pass a marginal negative spike (criteria exactly 9 C):
-    p = util.testingProfile.fakeProfile([2,-1,2], [1000,2000,3000]) 
+    p = util.testingProfile.fakeProfile([2,-1,2], [1000,2000,3000], latitude=0.0) 
     qc = qctests.Argo_gradient_test.test(p)
     truth = numpy.zeros(3, dtype=bool)
     assert numpy.array_equal(qc, truth), 'incorrectly flagging a negative spike exactly at threshold. (deep)' 
 
     # fail a marginal positive spike (criteria > 9 C):
-    p = util.testingProfile.fakeProfile([2,5.0001,2], [1000,2000,3000]) 
+    p = util.testingProfile.fakeProfile([2,5.0001,2], [1000,2000,3000], latitude=0.0) 
     qc = qctests.Argo_gradient_test.test(p)
     truth = numpy.zeros(3, dtype=bool)
     truth[1] = True 
     assert numpy.array_equal(qc, truth), 'failing to flag a positive spike just above threshold. (deep)'    
 
     # fail a marginal negative spike (criteria > 9 C):
-    p = util.testingProfile.fakeProfile([2,-1.0001,2], [1000,2000,3000]) 
+    p = util.testingProfile.fakeProfile([2,-1.0001,2], [1000,2000,3000], latitude=0.0) 
     qc = qctests.Argo_gradient_test.test(p)
     truth = numpy.zeros(3, dtype=bool)
     truth[1] = True
     assert numpy.array_equal(qc, truth), 'failing to flag a negative spike just above threshold. (deep)'
 
 def test_Argo_gradient_test_temperature_threshold():
-    '''
+    ''' 
     check AGT temperature behavior exactly at depth threshold (500m)
     '''
     # middle value should fail the deep check but pass the shallow check;
     # at threshold, use deep criteria
-    p = util.testingProfile.fakeProfile([2,5.0001,2], [400,500,600]) 
+    p = util.testingProfile.fakeProfile([2,5.0001,2], obs_utils.pressure_to_depth([400,500,600], 0.0), latitude=0.0) 
     qc = qctests.Argo_gradient_test.test(p)
     truth = numpy.zeros(3, dtype=bool)
     truth[1] = True 
     assert numpy.array_equal(qc, truth), 'failing to flag a positive spike just above threshold. (threshold)'      
 
     # as above, but passes just above 500m
-    p = util.testingProfile.fakeProfile([2,5.0001,2], [400,499,600]) 
+    p = util.testingProfile.fakeProfile([2,5.0001,2], obs_utils.pressure_to_depth([400,499,600], 0.0), latitude=0.0) 
     qc = qctests.Argo_gradient_test.test(p)
     truth = numpy.zeros(3, dtype=bool)
     assert numpy.array_equal(qc, truth), 'flagged a spike using deep criteria when shallow should have been used. (threshold)' 

--- a/tests/Argo_pressure_increasing_test_validation.py
+++ b/tests/Argo_pressure_increasing_test_validation.py
@@ -10,7 +10,7 @@ def test_Argo_pressure_increasing_test_constantPressure():
     API test should flag only the subsequent levels of constant pressure.
     '''
 
-    p = util.testingProfile.fakeProfile([2,2,2], [100,100,100]) 
+    p = util.testingProfile.fakeProfile([2,2,2], [100,100,100], latitude=0.0) 
     qc = qctests.Argo_pressure_increasing_test.test(p)
     truth = numpy.zeros(3, dtype=bool)
     truth[1] = True
@@ -22,7 +22,7 @@ def test_Argo_pressure_increasing_test_pressureInversion():
     API test should flag only the subsequent levels of constant pressure.
     '''
 
-    p = util.testingProfile.fakeProfile([2,2,2], [100,200,100]) 
+    p = util.testingProfile.fakeProfile([2,2,2], [100,200,100], latitude=0.0) 
     qc = qctests.Argo_pressure_increasing_test.test(p)
     truth = numpy.zeros(3, dtype=bool)
     truth[1] = True

--- a/tests/Argo_spike_test_validation.py
+++ b/tests/Argo_spike_test_validation.py
@@ -2,6 +2,7 @@ import qctests.Argo_spike_test
 
 import util.testingProfile
 import numpy
+from util import obs_utils
 
 ##### Argo_spike_test ---------------------------------------------------
 
@@ -15,26 +16,26 @@ def test_Argo_spike_test_temperature_shallow():
     ###
 
     # pass a marginal positive spike (criteria exactly 6 C):
-    p = util.testingProfile.fakeProfile([5,11,5], [100,200,300]) 
+    p = util.testingProfile.fakeProfile([5,11,5], [100,200,300], latitude=0.0) 
     qc = qctests.Argo_spike_test.test(p)
     truth = numpy.zeros(3, dtype=bool)
     assert numpy.array_equal(qc, truth), 'incorrectly flagging a positive spike exactly at threshold (shallow).'    
 
     # pass a marginal negative spike (criteria exactly 6 C):
-    p = util.testingProfile.fakeProfile([5,-1,5], [100,200,300]) 
+    p = util.testingProfile.fakeProfile([5,-1,5], [100,200,300], latitude=0.0) 
     qc = qctests.Argo_spike_test.test(p)
     truth = numpy.zeros(3, dtype=bool)
     assert numpy.array_equal(qc, truth), 'incorrectly flagging a negative spike exactly at threshold (shallow).' 
 
     # fail a marginal positive spike (criteria > 6 C):
-    p = util.testingProfile.fakeProfile([5,11.0001,5], [100,200,300]) 
+    p = util.testingProfile.fakeProfile([5,11.0001,5], [100,200,300], latitude=0.0) 
     qc = qctests.Argo_spike_test.test(p)
     truth = numpy.zeros(3, dtype=bool)
     truth[1] = True 
     assert numpy.array_equal(qc, truth), 'failing to flag a positive spike just above threshold (shallow).'    
 
     # fail a marginal negative spike (criteria > 6 C):
-    p = util.testingProfile.fakeProfile([5,-1.0001,5], [100,200,300]) 
+    p = util.testingProfile.fakeProfile([5,-1.0001,5], [100,200,300], latitude=0.0) 
     qc = qctests.Argo_spike_test.test(p)
     truth = numpy.zeros(3, dtype=bool)
     truth[1] = True
@@ -50,26 +51,26 @@ def test_Argo_spike_test_temperature_deep():
     ###
 
     # pass a marginal positive spike (criteria exactly 2 C):
-    p = util.testingProfile.fakeProfile([5,7,5], [1000,2000,3000]) 
+    p = util.testingProfile.fakeProfile([5,7,5], [1000,2000,3000], latitude=0.0) 
     qc = qctests.Argo_spike_test.test(p)
     truth = numpy.zeros(3, dtype=bool)
     assert numpy.array_equal(qc, truth), 'incorrectly flagging a positive spike exactly at threshold. (deep)'    
 
     # pass a marginal negative spike (criteria exactly 2 C):
-    p = util.testingProfile.fakeProfile([5,3,5], [1000,2000,3000]) 
+    p = util.testingProfile.fakeProfile([5,3,5], [1000,2000,3000], latitude=0.0) 
     qc = qctests.Argo_spike_test.test(p)
     truth = numpy.zeros(3, dtype=bool)
     assert numpy.array_equal(qc, truth), 'incorrectly flagging a negative spike exactly at threshold. (deep)' 
 
     # fail a marginal positive spike (criteria > 2 C):
-    p = util.testingProfile.fakeProfile([5,7.0001,5], [1000,2000,3000]) 
+    p = util.testingProfile.fakeProfile([5,7.0001,5], [1000,2000,3000], latitude=0.0) 
     qc = qctests.Argo_spike_test.test(p)
     truth = numpy.zeros(3, dtype=bool)
     truth[1] = True 
     assert numpy.array_equal(qc, truth), 'failing to flag a positive spike just above threshold. (deep)'    
 
     # fail a marginal negative spike (criteria > 2 C):
-    p = util.testingProfile.fakeProfile([5,2.999,5], [1000,2000,3000]) 
+    p = util.testingProfile.fakeProfile([5,2.999,5], [1000,2000,3000], latitude=0.0) 
     qc = qctests.Argo_spike_test.test(p)
     truth = numpy.zeros(3, dtype=bool)
     truth[1] = True
@@ -81,14 +82,14 @@ def test_Argo_spike_test_temperature_threshold():
     '''
     # middle value should fail the deep check but pass the shallow check;
     # at threshold, use deep criteria
-    p = util.testingProfile.fakeProfile([5,7.0001,5], [400,500,600]) 
+    p = util.testingProfile.fakeProfile([5,7.0001,5], obs_utils.pressure_to_depth([400,500,600], 0.0), latitude=0.0) 
     qc = qctests.Argo_spike_test.test(p)
     truth = numpy.zeros(3, dtype=bool)
     truth[1] = True 
     assert numpy.array_equal(qc, truth), 'failing to flag a positive spike just above threshold. (threshold)'      
 
     # as above, but passes just above 500m
-    p = util.testingProfile.fakeProfile([5,7.0001,5], [400,499,600]) 
+    p = util.testingProfile.fakeProfile([5,7.0001,5], obs_utils.pressure_to_depth([400,499,600], 0.0), latitude=0.0) 
     qc = qctests.Argo_spike_test.test(p)
     truth = numpy.zeros(3, dtype=bool)
     assert numpy.array_equal(qc, truth), 'flagged a spike using deep criteria when shallow should have been used. (threshold)' 

--- a/tests/obs_utils_tests.py
+++ b/tests/obs_utils_tests.py
@@ -29,14 +29,6 @@ def pottem_test():
 
     assert True
 
-def depth_to_pressure_scalar_test():
-    '''
-    implements spot check suggested from original code,
-    to 6 places.
-    '''
-
-    assert np.round(1e6*outils._depth_to_pressure_scalar(10000, 30.0)) == 10302423165, 'failed to match expectation at test point'
-
 def depth_to_pressure_test():
     '''
     check behavior of depth_to_pressure for different input shapes.
@@ -44,7 +36,7 @@ def depth_to_pressure_test():
 
     lat = 30.0
     depth = 10000
-    truePressure = 10302423165
+    truePressure = 10300977189
 
     #two single value arrays
     assert np.round(1e6*outils.depth_to_pressure( np.array([depth]), np.array([lat]) )) == truePressure, 'failed to match expectation for 2 single-valued arrays'
@@ -70,12 +62,12 @@ def pressure_to_depth_test():
     '''
 
     # for scalars
-    assert np.round(outils.pressure_to_depth(10000, 30.0)*1000) == 9712653
+    assert np.round(outils.pressure_to_depth(10000, 30.0)*1000) == 9713735
 
     # for numpy arrays
     depths = outils.pressure_to_depth(np.array([10000, 10000, 10000]), np.array([30.0, 30.0, 30.0]))
     for i in range(len(depths)):
-        assert np.round(depths[i]*1000) == 9712653
+        assert np.round(depths[i]*1000) == 9713735
 
 
 def density_test():


### PR DESCRIPTION
Argo tests are designed to work on pressure so this change corrects the previous implementation. GSW (Python version of the TEOS-10 software) is now used for depth-pressure conversion.