### PR TITLE
fixed bashrc inclusion in dockerfile, added some more data

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,11 @@ ADD woa13_decav_t13_5dv2.nc /AutoQC/data/.
 ADD woa13_decav_t14_5dv2.nc /AutoQC/data/.
 ADD woa13_decav_t15_5dv2.nc /AutoQC/data/.
 ADD woa13_decav_t16_5dv2.nc /AutoQC/data/.
+ADD woa13_decav_s13_5dv2.nc /AutoQC/data/.
+ADD woa13_decav_s14_5dv2.nc /AutoQC/data/.
+ADD woa13_decav_s15_5dv2.nc /AutoQC/data/.
+ADD woa13_decav_s16_5dv2.nc /AutoQC/data/.
 ADD etopo5.nc /AutoQC/data/.
 ADD climatological_t_median_and_amd_for_aqc.nc /AutoQC/data/.
 
-ADD bashrc ~/.bashrc
+ADD bashrc /.bashrc


### PR DESCRIPTION
This fixes two issues:

 - the `.bashrc` @castelao requested was not getting included properly before (my mistake from #159 )
 - since last I checked, `woa13_decav_s13_5dv2.nc` through `s16` are downloaded if unavailable; these are now in the docker image.

The image on dockerhub already reflects these changes.