### PR TITLE
fix CSIRO_constant_bottom edge case

### DIFF
--- a/qctests/CSIRO_constant_bottom.py
+++ b/qctests/CSIRO_constant_bottom.py
@@ -28,6 +28,10 @@ def test(p):
     isDepth = (d.mask==False)
     isData = isTemperature & isDepth
 
+    # need more than one level
+    if len(isData) < 2:
+        return qc
+
     # constant temperature at bottom of profile, for latitude > -40 and bottom two depths at least 30m apart:
     if isData[-1] and isData[-2] and isXBT:
         if t.data[-1] == t.data[-2] and latitude > -40 and d.data[-1] - d.data[-2] > 30:

--- a/tests/CSIRO_constant_bottom_validation.py
+++ b/tests/CSIRO_constant_bottom_validation.py
@@ -41,3 +41,9 @@ def test_CSIRO_constant_bottom():
     qc = qctests.CSIRO_constant_bottom.test(p)
 
     assert numpy.array_equal(qc, truth), 'flagged a constant temperature not at the bottom of the profile'
+
+    # don't run with only one level
+    p = util.testingProfile.fakeProfile([0], [100], latitude=0, longitude=0, probe_type=2)
+    qc = qctests.CSIRO_constant_bottom.test(p)
+    truth = numpy.zeros(1, dtype=bool)
+    assert numpy.array_equal(qc, truth), 'cant perform this check with a single-level profile'    


### PR DESCRIPTION
patches edge case where `CSIRO_constant_bottom` would error out on a profile with only a single level.