### PR TITLE
futureproof against numpy warning

### DIFF
--- a/qctests/EN_background_check.py
+++ b/qctests/EN_background_check.py
@@ -130,13 +130,13 @@ def findGridCell(p, gridLong, gridLat):
     lon = p.longitude()
     grid = gridLong
     nlon = len(grid)
-    ilon = np.mod(np.round((lon - grid[0]) / (grid[1] - grid[0])), nlon)
+    ilon = int(np.mod(np.round((lon - grid[0]) / (grid[1] - grid[0])), nlon))
     for i in range(1, len(gridLat)):
         assert gridLat[i] - gridLat[i-1] == gridLat[1] - gridLat[0], 'latitude grid points must be evenly spaced'
     lat = p.latitude()
     grid = gridLat
     nlat = len(grid)
-    ilat = np.mod(np.round((lat - grid[0]) / (grid[1] - grid[0])), nlat)
+    ilat = int(np.mod(np.round((lat - grid[0]) / (grid[1] - grid[0])), nlat))
     if ilat == nlat: ilat -= 1 # Checks for edge case where lat is ~90.
     
     assert ilon >=0 and ilon < nlon, 'Longitude is out of range: %f %i' % (lon, ilon)


### PR DESCRIPTION
`EN_background` was complaining about non-integer array indices, threatening a deprecation in future; typecasting indices to ints shouldn't cause any problems. 