### PR TITLE
stopping wod test from breaking when datafiles.json changes

### DIFF
--- a/tests/wod_tests.py
+++ b/tests/wod_tests.py
@@ -3,7 +3,7 @@ from wodpy import wod
 
 class TestClass:
    def setUp(self):
-        filenames = main.readInput('datafiles.json')
+        filenames = ["data/quota_subset.dat"]
         profiles = main.extractProfiles(filenames)
 
         # identify and import tests


### PR DESCRIPTION
while all tests are passing happily on travis, nose kept killing my test suite locally - this was because I had been running tests after fooling around with `datafiles.json`, which `wod_test.py` was trying to read. This PR decouples the two.