### PR TITLE
Cotede config format

### DIFF
--- a/AutoQC.py
+++ b/AutoQC.py
@@ -39,8 +39,6 @@ def processFile(fName):
   data.ds.threadFile     = fName
 
   for iprofile, pinfo in enumerate(data.ds.threadProfiles):
-    if iprofile >=10:
-      continue
     # Load the profile data.
     p, currentFile, f = main.profileData(pinfo, currentFile, f)
     # Check that there are temperature data in the profile, otherwise skip.

--- a/AutoQC.py
+++ b/AutoQC.py
@@ -3,7 +3,7 @@ import glob, time
 import numpy as np
 import sys, os, json, data.ds
 import util.main as main
-import pandas
+import pandas, logging
 
 def run(test, profiles):
   '''
@@ -39,6 +39,8 @@ def processFile(fName):
   data.ds.threadFile     = fName
 
   for iprofile, pinfo in enumerate(data.ds.threadProfiles):
+    if iprofile >=10:
+      continue
     # Load the profile data.
     p, currentFile, f = main.profileData(pinfo, currentFile, f)
     # Check that there are temperature data in the profile, otherwise skip.
@@ -72,6 +74,8 @@ def processFile(fName):
 ########################################
 
 if len(sys.argv)>2:
+  # no debug messages by default
+  logging.disable('info')
   # Identify and import tests
   testNames = main.importQC('qctests')
   testNames.sort()

--- a/cotede_qc/qc_cfg/cotede.json
+++ b/cotede_qc/qc_cfg/cotede.json
@@ -11,17 +11,21 @@
         "vars": {"woa_an": "t_mn", "woa_sd": "t_sd", "woa_n": "t_dd"},
         "url": ""
         },
-    "spike": 6.0,
+    "spike": {
+        "threshold":6.0
+        },
     "spike_depthconditional": {
         "pressure_threshold": 500,
         "shallow_max": 6.0,
         "deep_max": 2.0
         },
     "tukey53H_norm": {
-        "k": 1.5,
+        "threshold": 1.5,
         "l": 12
         },
-    "gradient": 9.0,
+    "gradient": {
+        "threshold":9.0
+        },
     "digit_roll_over": 10,
     "bin_spike": {
         "l": 5,

--- a/cotede_qc/qc_cfg/fuzzy.json
+++ b/cotede_qc/qc_cfg/fuzzy.json
@@ -1,6 +1,8 @@
 {
 "TEMP": {
-    "spike": 6.0,
+    "spike": {
+        "threshold":6.0
+        },
     "woa_normbias": {
         "sigma_threshold": 6,
         "file": "data/temperature_seasonal_5deg.nc",

--- a/cotede_qc/qc_cfg/gtspp.json
+++ b/cotede_qc/qc_cfg/gtspp.json
@@ -4,8 +4,12 @@
         "minval": -2.0,
         "maxval": 40
         },
-    "gradient": 10.0,
-    "spike": 2.0,
+    "gradient": {
+        "threshold":10.0
+        },
+    "spike": {
+        "threshold":2.0
+        },
     "woa_normbias": {
         "sigma_threshold": 3,
         "file": "data/temperature_seasonal_5deg.nc",


### PR DESCRIPTION
At the moment, running the CoTeDe tests produces a huge number of warnings:

```
Deprecated cfg format. It should contain a threshold item.
``` 

This is due to a change in config file format in CoTeDe, which this PR attempts to address. The json changes in `cotede_qc/qc_cfg/` are meant to reflect the pattern and spirit of https://github.com/castelao/CoTeDe/commit/23dfdca96da7942514d4563da3fa26f23d5620a5 and https://github.com/castelao/CoTeDe/commit/3819361becc7669542aadc0892ae2d653ad06089, and have the desired effect of eliminating the warnings - but as I have not had much involvement in the CoTeDe integration part of this project, I'd like a second opinion before we merge; cc @castelao @s-good.