### PR TITLE
Exclude profiles pre-1900

### DIFF
--- a/build-db.py
+++ b/build-db.py
@@ -56,9 +56,16 @@ if len(sys.argv) == 3:
         wodDict['raw'] = "'" + raw + "'"
         # Below avoids failures if all profile data are missing.
         # We have no use for this profile in that case so skip it.
+        donotuse = False
         try:
             wodDict['truth'] = sum(profile.t_level_qc(originator=True) >= 3) >= 1
         except:
+            donotuse = True
+        # Cannot process profiles collected before 1900 at present as datetime strftime
+        # function used by CoTeDe gives an error.
+        if profile.year() < 1900:
+            donotuse = True
+        if donotuse:
             if profile.is_last_profile_in_file(fid) == True:
                 break
             continue


### PR DESCRIPTION
As mentioned in #165 CoTeDe uses a datetime function that cannot handle dates before 1900. This filters out those observations from being put in the database.

Alternative is to leave them in and exclude them from going through the quality control in AutoQC.py. However that could cause confusion later when analysing results and it is straightforward to add extra rows to the database at a later time if we want to process them.

NB this only affects a very small number of profiles - in QuOTA is ~180 out 350000