### PR TITLE
allow cotede tests to gracefully fail

### DIFF
--- a/qctests/CoTeDe_Argo_density_inversion.py
+++ b/qctests/CoTeDe_Argo_density_inversion.py
@@ -1,11 +1,17 @@
 from cotede_qc.cotede_test import get_qc
+import numpy
 
 def test(p, parameters):
     '''Run the density inversion QC from the CoTeDe Argo config.'''
 
     config   = 'argo'
     testname = 'density_inversion'
+    
+    try:
+        qc = get_qc(p, config, testname)
+    except:
+        qc = numpy.zeros(1, dtype=bool)
 
-    return get_qc(p, config, testname)
+    return qc
 
 

--- a/qctests/CoTeDe_GTSPP_WOA_normbias.py
+++ b/qctests/CoTeDe_GTSPP_WOA_normbias.py
@@ -1,11 +1,16 @@
 from cotede_qc.cotede_test import get_qc
+import numpy
 
 def test(p, parameters):
     '''Run the WOA normbias QC from the CoTeDe GTSPP config.'''
 
     config   = 'gtspp'
     testname = 'woa_normbias'
+ 
+    try:
+        qc = get_qc(p, config, testname)
+    except:
+        qc = numpy.zeros(1, dtype=bool)
 
-    return get_qc(p, config, testname)
-
+    return qc
 

--- a/qctests/CoTeDe_GTSPP_global_range.py
+++ b/qctests/CoTeDe_GTSPP_global_range.py
@@ -1,4 +1,5 @@
 from cotede_qc.cotede_test import get_qc
+import numpy
 
 def test(p, parameters):
     '''Run the global range QC from the CoTeDe GTSPP config.'''
@@ -6,6 +7,11 @@ def test(p, parameters):
     config   = 'gtspp'
     testname = 'global_range'
 
-    return get_qc(p, config, testname)
+    try:
+        qc = get_qc(p, config, testname)
+    except:
+        qc = numpy.zeros(1, dtype=bool)
+
+    return qc
 
 

--- a/qctests/CoTeDe_GTSPP_gradient.py
+++ b/qctests/CoTeDe_GTSPP_gradient.py
@@ -1,4 +1,5 @@
 from cotede_qc.cotede_test import get_qc
+import numpy
 
 def test(p, parameters):
     '''Run the gradient QC from the CoTeDe GTSPP config.'''
@@ -6,6 +7,11 @@ def test(p, parameters):
     config   = 'gtspp'
     testname = 'gradient'
 
-    return get_qc(p, config, testname)
+    try:
+        qc = get_qc(p, config, testname)
+    except:
+        qc = numpy.zeros(1, dtype=bool)
+
+    return qc
 
 

--- a/qctests/CoTeDe_GTSPP_profile_envelop.py
+++ b/qctests/CoTeDe_GTSPP_profile_envelop.py
@@ -1,4 +1,5 @@
 from cotede_qc.cotede_test import get_qc
+import numpy
 
 def test(p, parameters):
     '''Run the profile_envelop QC from the CoTeDe config.'''
@@ -6,6 +7,11 @@ def test(p, parameters):
     config   = 'cotede'
     testname = 'profile_envelop'
 
-    return get_qc(p, config, testname)
+    try:
+        qc = get_qc(p, config, testname)
+    except:
+        qc = numpy.zeros(1, dtype=bool)
+
+    return qc
 
 

--- a/qctests/CoTeDe_GTSPP_spike_check.py
+++ b/qctests/CoTeDe_GTSPP_spike_check.py
@@ -1,4 +1,5 @@
 from cotede_qc.cotede_test import get_qc
+import numpy
 
 def test(p, parameters):
     '''Run the spike QC from the CoTeDe GTSPP config.'''
@@ -6,6 +7,11 @@ def test(p, parameters):
     config   = 'gtspp'
     testname = 'spike'
 
-    return get_qc(p, config, testname)
+    try:
+        qc = get_qc(p, config, testname)
+    except:
+        qc = numpy.zeros(1, dtype=bool)
+
+    return qc
 
 

--- a/qctests/CoTeDe_Morello2014.py
+++ b/qctests/CoTeDe_Morello2014.py
@@ -1,11 +1,17 @@
 from cotede_qc.cotede_test import get_qc
+import numpy
 
 def test(p, parameters):
     '''Run the CoTeDe Morello 2014 QC.'''
 
     config   = 'morello2014'
     testname = 'morello2014'
+   
+    try:
+        qc = get_qc(p, config, testname)
+    except:
+        qc = numpy.zeros(1, dtype=bool)
 
-    return get_qc(p, config, testname)
+    return qc
 
 

--- a/qctests/CoTeDe_WOA_normbias.py
+++ b/qctests/CoTeDe_WOA_normbias.py
@@ -1,4 +1,5 @@
 from cotede_qc.cotede_test import get_qc
+import numpy
 
 def test(p, parameters):
     '''Run the WOA normbias QC from the CoTeDe config.'''
@@ -6,6 +7,11 @@ def test(p, parameters):
     config   = 'cotede'
     testname = 'woa_normbias'
 
-    return get_qc(p, config, testname)
+    try:
+        qc =get_qc(p, config, testname)
+    except:
+        qc = numpy.zeros(1, dtype=bool)
+
+    return qc
 
 

--- a/qctests/CoTeDe_anomaly_detection.py
+++ b/qctests/CoTeDe_anomaly_detection.py
@@ -1,4 +1,5 @@
 from cotede_qc.cotede_test import get_qc
+import numpy
 
 def test(p, parameters):
     '''Run the CoTeDe Anomaly Detection QC.'''
@@ -6,6 +7,11 @@ def test(p, parameters):
     config   = 'anomaly_detection'
     testname = 'anomaly_detection'
 
-    return get_qc(p, config, testname)
+    try:
+        qc = get_qc(p, config, testname)
+    except:
+        qc = numpy.zeros(1, dtype=bool)
+
+    return qc
 
 

--- a/qctests/CoTeDe_digit_roll_over.py
+++ b/qctests/CoTeDe_digit_roll_over.py
@@ -1,4 +1,5 @@
 from cotede_qc.cotede_test import get_qc
+import numpy
 
 def test(p, parameters):
     '''Run the digit roll over QC from the CoTeDe config.'''
@@ -6,6 +7,10 @@ def test(p, parameters):
     config   = 'cotede'
     testname = 'digit_roll_over'
 
-    return get_qc(p, config, testname)
+    try:
+        qc = get_qc(p, config, testname)
+    except:
+        qc = numpy.zeros(1, dtype=bool)
 
+    return qc
 

--- a/qctests/CoTeDe_fuzzy_logic.py
+++ b/qctests/CoTeDe_fuzzy_logic.py
@@ -1,4 +1,5 @@
 from cotede_qc.cotede_test import get_qc
+import numpy
 
 def test(p, parameters):
     '''Run the CoTeDe fuzzy logic QC.'''
@@ -6,6 +7,10 @@ def test(p, parameters):
     config   = 'fuzzylogic'
     testname = 'fuzzylogic'
 
-    return get_qc(p, config, testname)
+    try:
+        qc = get_qc(p, config, testname)
+    except:
+        qc = numpy.zeros(1, dtype=bool)
 
+    return qc
 

--- a/qctests/CoTeDe_gradient.py
+++ b/qctests/CoTeDe_gradient.py
@@ -1,4 +1,5 @@
 from cotede_qc.cotede_test import get_qc
+import numpy
 
 def test(p, parameters):
     '''Run the gradient QC from the CoTeDe config.'''
@@ -6,6 +7,10 @@ def test(p, parameters):
     config   = 'cotede'
     testname = 'gradient'
 
-    return get_qc(p, config, testname)
+    try:
+        qc = get_qc(p, config, testname)
+    except:
+        qc = numpy.zeros(1, dtype=bool)
 
+    return qc
 

--- a/qctests/CoTeDe_location_at_sea_test.py
+++ b/qctests/CoTeDe_location_at_sea_test.py
@@ -1,4 +1,5 @@
 from cotede_qc.cotede_test import get_qc
+import numpy
 
 def test(p, parameters):
     '''Run the CoTeDe location at sea QC.'''
@@ -6,6 +7,10 @@ def test(p, parameters):
     config   = 'cotede'
     testname = 'location_at_sea'
     
-    return get_qc(p, config, testname)
+    try:
+        qc = get_qc(p, config, testname)
+    except:
+        qc = numpy.zeros(1, dtype=bool)
 
+    return qc
 

--- a/qctests/CoTeDe_rate_of_change.py
+++ b/qctests/CoTeDe_rate_of_change.py
@@ -1,4 +1,5 @@
 from cotede_qc.cotede_test import get_qc
+import numpy
 
 def test(p, parameters):
     '''Run the rate_of_change QC from the CoTeDe config.'''
@@ -6,6 +7,10 @@ def test(p, parameters):
     config   = 'cotede'
     testname = 'rate_of_change'
 
-    return get_qc(p, config, testname)
+    try:
+        qc = get_qc(p, config, testname)
+    except:
+        qc = numpy.zeros(1, dtype=bool)
 
+    return qc
 

--- a/qctests/CoTeDe_spike.py
+++ b/qctests/CoTeDe_spike.py
@@ -1,4 +1,5 @@
 from cotede_qc.cotede_test import get_qc
+import numpy
 
 def test(p, parameters):
     '''Run the spike QC from the CoTeDe config.'''
@@ -6,6 +7,10 @@ def test(p, parameters):
     config   = 'cotede'
     testname = 'spike'
 
-    return get_qc(p, config, testname)
+    try:
+        qc = get_qc(p, config, testname)
+    except:
+        qc = numpy.zeros(1, dtype=bool)
 
+    return qc
 

--- a/qctests/CoTeDe_tukey53H_norm.py
+++ b/qctests/CoTeDe_tukey53H_norm.py
@@ -1,4 +1,5 @@
 from cotede_qc.cotede_test import get_qc
+import numpy
 
 def test(p, parameters):
     '''Run the tukey53H norm QC from the CoTeDe config.'''
@@ -6,6 +7,10 @@ def test(p, parameters):
     config   = 'cotede'
     testname = 'tukey53H_norm'
 
-    return get_qc(p, config, testname)
+    try:
+        qc = get_qc(p, config, testname)
+    except:
+        qc = numpy.zeros(1, dtype=bool)
 
+    return qc
 


### PR DESCRIPTION
wraps cotede tests in a try / except so if anything goes wrong, no flag is raised and qc continues smoothly.

In response to #184, though does not address the fundamental issue upstream in cotede pointed out there.