### PR TITLE
Process-level parallelization II

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,8 @@ services:
 before_install:
 - docker pull iquod/autoqc
 
+env:
+- OCEANSDB_DIR=/AutoQC/data/
+
 script:
 - docker run -v $PWD:/AutoQC_latest iquod/autoqc /bin/bash -c "cp /AutoQC/data/* /AutoQC_latest/data/.; cd /AutoQC_latest; nosetests tests/*.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,5 @@ services:
 before_install:
 - docker pull iquod/autoqc
 
-env:
-- OCEANSDB_DIR=/AutoQC/data/
-
 script:
 - docker run -v $PWD:/AutoQC_latest iquod/autoqc /bin/bash -c "cp /AutoQC/data/* /AutoQC_latest/data/.; cd /AutoQC_latest; nosetests tests/*.py"

--- a/AutoQC.py
+++ b/AutoQC.py
@@ -72,11 +72,11 @@ if len(sys.argv)>2:
       print 'No parameters to load for', test
       
   # connect to database & fetch list of all uids
-  query = 'SELECT uid FROM ' + sys.argv[1]
+  query = 'SELECT uid FROM ' + sys.argv[1] + ' ORDER BY uid OFFSET ' + sys.argv[2] + ' LIMIT ' + str(int(sys.argv[3]) - int(sys.argv[2])) + ';' 
   uids = main.dbinteract(query)
   
   # launch async processes
-  pool = Pool(processes=int(sys.argv[2]))
+  pool = Pool(processes=1)
   for i in range(len(uids)):
     pool.apply_async(process_row, (uids[i][0],))
   pool.close()
@@ -84,5 +84,5 @@ if len(sys.argv)>2:
     
 else:
   print 'Please add command line arguments to name your output file and set parallelization:'
-  print 'python AutoQC <test group> <database table>'
-  print 'will write qc results to <database table> in the database, and run the calculation parallelized across <number of threads> cores.'
+  print 'python AutoQC <database table> <from> <to>'
+  print 'will write qc results to <database table> in the database, and run the calculation on database rows starting at <from> and going to but not including <to>.'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,4 +33,6 @@ ADD climatological_t_median_and_amd_for_aqc.nc /AutoQC/data/.
 # set up database; load quota_subset.dat into a table 'demo'.
 RUN /etc/init.d/postgresql start && su postgres -c 'createuser -s root' && su postgres -c 'createdb root'
 
+ENV OCEANSDB_DIR /AutoQC/data/
+
 ADD bashrc /.bashrc

--- a/launchQC.sh
+++ b/launchQC.sh
@@ -1,4 +1,4 @@
-# bash launchQC.sh <number of profiles> <number of processes>
+# bash launchQC.sh <database table> <number of profiles> <number of processes>
 
 QUEUE=$(($2 / $3))
 
@@ -7,4 +7,4 @@ do
   python AutoQC.py $1 $(($i * $QUEUE)) $(($(($i + 1)) * $QUEUE)) &
 done
 
-python AutoQC.py demo $(( $(($i + 1)) * $QUEUE)) $1 &
+python AutoQC.py $1 $(( $(($i + 1)) * $QUEUE)) $2 &

--- a/launchQC.sh
+++ b/launchQC.sh
@@ -1,0 +1,10 @@
+# bash launchQC.sh <number of profiles> <number of processes>
+
+QUEUE=$(($2 / $3))
+
+for i in `seq 0 $(($3 - 2))`
+do
+  python AutoQC.py $1 $(($i * $QUEUE)) $(($(($i + 1)) * $QUEUE)) &
+done
+
+python AutoQC.py demo $(( $(($i + 1)) * $QUEUE)) $1 &

--- a/util/main.py
+++ b/util/main.py
@@ -190,7 +190,7 @@ def dbinteract(command, tries=0):
     conn.rollback()
     cur.close()
     conn.close()
-    if tries < max_retries:
+    if tries < max_retry:
       dbinteract(command, tries+1)
     else:
       return -1


### PR DESCRIPTION
This PR replaces #191, with the key update that bashrc files are not run when not logging into a docker container interactively, which is the case on Travis; therefore, environment variables must be set in the Dockerfile. Note the new Docker image hasn't been pushed at the time of this writing (so tests will still be failing), but should become available in about an hour.