### PR TITLE
correct and protect course correction angle calculation

### DIFF
--- a/tests/geo_tests.py
+++ b/tests/geo_tests.py
@@ -62,7 +62,7 @@ def test_deltaTime_times():
     diff = geo.deltaTime(early, late)
     assert diff == 82800., 'incorrect time difference for earlier times but later days'
 
-def test_haversineAngle():
+def test_courseCorrection():
     '''
     check some nominal behavior of great circle intersections.
     '''
@@ -74,12 +74,12 @@ def test_haversineAngle():
     lat3 = 0
     lon3 = 30
 
-    angle = geo.haversineAngle(lat1, lon1, lat2, lon2, lat3, lon3) 
-    assert angle - math.pi < 0.000001, 'point on a circle had a non-zero angle between them: %f' % angle
+    angle = geo.courseCorrection(lat1, lon1, lat2, lon2, lat3, lon3) 
+    assert angle < 0.000001, 'point on a circle had a non-zero angle between them: %f' % angle
 
     lat3 = 90
     lon3 = 20
-    angle = geo.haversineAngle(lat1, lon1, lat2, lon2, lat3, lon3)
+    angle = geo.courseCorrection(lat1, lon1, lat2, lon2, lat3, lon3)
     assert angle - math.pi/2 < 0.000001, 'orthogonal great circles had an angle of %f between them.' % angle
 
 def test_archaversine_domain():

--- a/tests/geo_tests.py
+++ b/tests/geo_tests.py
@@ -62,7 +62,7 @@ def test_deltaTime_times():
     diff = geo.deltaTime(early, late)
     assert diff == 82800., 'incorrect time difference for earlier times but later days'
 
-def test_courseCorrection():
+def test_haversineAngle():
     '''
     check some nominal behavior of great circle intersections.
     '''
@@ -74,12 +74,12 @@ def test_courseCorrection():
     lat3 = 0
     lon3 = 30
 
-    angle = geo.courseCorrection(lat1, lon1, lat2, lon2, lat3, lon3) 
-    assert angle < 0.000001, 'point on a circle had a non-zero angle between them: %f' % angle
+    angle = geo.haversineAngle(lat1, lon1, lat2, lon2, lat3, lon3) 
+    assert angle - math.pi < 0.000001, 'point on a circle had a non-zero angle between them: %f' % angle
 
     lat3 = 90
     lon3 = 20
-    angle = geo.courseCorrection(lat1, lon1, lat2, lon2, lat3, lon3)
+    angle = geo.haversineAngle(lat1, lon1, lat2, lon2, lat3, lon3)
     assert angle - math.pi/2 < 0.000001, 'orthogonal great circles had an angle of %f between them.' % angle
 
 def test_archaversine_domain():

--- a/util/geo.py
+++ b/util/geo.py
@@ -39,10 +39,10 @@ def haversineDistance(lat1, lon1, lat2, lon2):
     assert km >= 0, 'haversine returned negative distance'
     return km*1000.
 
-def haversineAngle(lat1, lon1, lat2, lon2, lat3, lon3):
+def courseCorrection(lat1, lon1, lat2, lon2, lat3, lon3):
     '''
-    Calculate the angle subtended by the great circle passing through lat/lon1 and lat/lon2,
-    with that passing through lat/lon2 and lat/lon3
+    Calculate the course correction angle between an initial track from lat/lon1 to lat/lon2,
+    and a post-correction track from lat/lon2 and lat/lon3
     return None if any required information is missing.
     '''
     
@@ -56,9 +56,13 @@ def haversineAngle(lat1, lon1, lat2, lon2, lat3, lon3):
     if a == 0 or b == 0:
         return 0
 
-    C = arcHaversine( (haversine(c) - haversine(a-b)) / math.sin(a) / math.sin(b) )
+    cosC = (math.cos(c) - math.cos(a)*math.cos(b))/math.sin(a)/math.sin(b)
+    if cosC > 1:
+        cosC = 1
+    if cosC < -1:
+        cosC = -1
 
-    return C
+    return math.pi - math.acos(cosC)
 
 def deltaTime(earlier, later):
     '''

--- a/util/geo.py
+++ b/util/geo.py
@@ -39,10 +39,10 @@ def haversineDistance(lat1, lon1, lat2, lon2):
     assert km >= 0, 'haversine returned negative distance'
     return km*1000.
 
-def courseCorrection(lat1, lon1, lat2, lon2, lat3, lon3):
+def haversineAngle(lat1, lon1, lat2, lon2, lat3, lon3):
     '''
-    Calculate the course correction angle between an initial track from lat/lon1 to lat/lon2,
-    and a post-correction track from lat/lon2 and lat/lon3
+    Calculate the angle subtended by the great circle passing through lat/lon1 and lat/lon2,
+    with that passing through lat/lon2 and lat/lon3
     return None if any required information is missing.
     '''
     
@@ -62,7 +62,7 @@ def courseCorrection(lat1, lon1, lat2, lon2, lat3, lon3):
     if cosC < -1:
         cosC = -1
 
-    return math.pi - math.acos(cosC)
+    return math.acos(cosC)
 
 def deltaTime(earlier, later):
     '''


### PR DESCRIPTION
at least a partial response to the discussion in #209:

 - Avoids the use of `archaversine` when calculating angles between track segments, and the corresponding pathology, by using the analogous spherical law of cosines instead, with enforcement of [-1,1] arguments for arccos.
 - Doesn't actually do anything about archaversine itself; as I said in #209, I think that function should complain about negative arguments, since (non-imaginary) haversines should always be positive.