### PR TITLE
addressed parallelization issues with sqlite db backing

### DIFF
--- a/build-db.py
+++ b/build-db.py
@@ -19,7 +19,7 @@ if len(sys.argv) == 3:
     query = "CREATE TABLE " + sys.argv[2] + """(
                 raw text,
                 truth BLOB,
-                uid integer,
+                uid integer PRIMARY KEY,
                 year integer,
                 month integer,
                 day integer,

--- a/qctests/CoTeDe_Argo_density_inversion.py
+++ b/qctests/CoTeDe_Argo_density_inversion.py
@@ -7,10 +7,7 @@ def test(p, parameters):
     config   = 'argo'
     testname = 'density_inversion'
     
-    try:
-        qc = get_qc(p, config, testname)
-    except:
-        qc = numpy.zeros(1, dtype=bool)
+    qc = get_qc(p, config, testname)
 
     return qc
 

--- a/qctests/CoTeDe_GTSPP_WOA_normbias.py
+++ b/qctests/CoTeDe_GTSPP_WOA_normbias.py
@@ -7,10 +7,7 @@ def test(p, parameters):
     config   = 'gtspp'
     testname = 'woa_normbias'
  
-    try:
-        qc = get_qc(p, config, testname)
-    except:
-        qc = numpy.zeros(1, dtype=bool)
-
+    qc = get_qc(p, config, testname)
+    
     return qc
 

--- a/qctests/CoTeDe_GTSPP_global_range.py
+++ b/qctests/CoTeDe_GTSPP_global_range.py
@@ -7,10 +7,7 @@ def test(p, parameters):
     config   = 'gtspp'
     testname = 'global_range'
 
-    try:
-        qc = get_qc(p, config, testname)
-    except:
-        qc = numpy.zeros(1, dtype=bool)
+    qc = get_qc(p, config, testname)
 
     return qc
 

--- a/qctests/CoTeDe_GTSPP_gradient.py
+++ b/qctests/CoTeDe_GTSPP_gradient.py
@@ -7,10 +7,7 @@ def test(p, parameters):
     config   = 'gtspp'
     testname = 'gradient'
 
-    try:
-        qc = get_qc(p, config, testname)
-    except:
-        qc = numpy.zeros(1, dtype=bool)
+    qc = get_qc(p, config, testname)
 
     return qc
 

--- a/qctests/CoTeDe_GTSPP_profile_envelop.py
+++ b/qctests/CoTeDe_GTSPP_profile_envelop.py
@@ -7,10 +7,7 @@ def test(p, parameters):
     config   = 'cotede'
     testname = 'profile_envelop'
 
-    try:
-        qc = get_qc(p, config, testname)
-    except:
-        qc = numpy.zeros(1, dtype=bool)
+    qc = get_qc(p, config, testname)
 
     return qc
 

--- a/qctests/CoTeDe_GTSPP_spike_check.py
+++ b/qctests/CoTeDe_GTSPP_spike_check.py
@@ -7,10 +7,7 @@ def test(p, parameters):
     config   = 'gtspp'
     testname = 'spike'
 
-    try:
-        qc = get_qc(p, config, testname)
-    except:
-        qc = numpy.zeros(1, dtype=bool)
+    qc = get_qc(p, config, testname)
 
     return qc
 

--- a/qctests/CoTeDe_Morello2014.py
+++ b/qctests/CoTeDe_Morello2014.py
@@ -7,10 +7,7 @@ def test(p, parameters):
     config   = 'morello2014'
     testname = 'morello2014'
    
-    try:
-        qc = get_qc(p, config, testname)
-    except:
-        qc = numpy.zeros(1, dtype=bool)
+    qc = get_qc(p, config, testname)
 
     return qc
 

--- a/qctests/CoTeDe_WOA_normbias.py
+++ b/qctests/CoTeDe_WOA_normbias.py
@@ -7,10 +7,7 @@ def test(p, parameters):
     config   = 'cotede'
     testname = 'woa_normbias'
 
-    try:
-        qc =get_qc(p, config, testname)
-    except:
-        qc = numpy.zeros(1, dtype=bool)
+    qc =get_qc(p, config, testname)
 
     return qc
 

--- a/qctests/CoTeDe_anomaly_detection.py
+++ b/qctests/CoTeDe_anomaly_detection.py
@@ -7,10 +7,7 @@ def test(p, parameters):
     config   = 'anomaly_detection'
     testname = 'anomaly_detection'
 
-    try:
-        qc = get_qc(p, config, testname)
-    except:
-        qc = numpy.zeros(1, dtype=bool)
+    qc = get_qc(p, config, testname)
 
     return qc
 

--- a/qctests/CoTeDe_digit_roll_over.py
+++ b/qctests/CoTeDe_digit_roll_over.py
@@ -7,10 +7,7 @@ def test(p, parameters):
     config   = 'cotede'
     testname = 'digit_roll_over'
 
-    try:
-        qc = get_qc(p, config, testname)
-    except:
-        qc = numpy.zeros(1, dtype=bool)
+    qc = get_qc(p, config, testname)
 
     return qc
 

--- a/qctests/CoTeDe_fuzzy_logic.py
+++ b/qctests/CoTeDe_fuzzy_logic.py
@@ -7,10 +7,7 @@ def test(p, parameters):
     config   = 'fuzzylogic'
     testname = 'fuzzylogic'
 
-    try:
-        qc = get_qc(p, config, testname)
-    except:
-        qc = numpy.zeros(1, dtype=bool)
+    qc = get_qc(p, config, testname)
 
     return qc
 

--- a/qctests/CoTeDe_gradient.py
+++ b/qctests/CoTeDe_gradient.py
@@ -7,10 +7,7 @@ def test(p, parameters):
     config   = 'cotede'
     testname = 'gradient'
 
-    try:
-        qc = get_qc(p, config, testname)
-    except:
-        qc = numpy.zeros(1, dtype=bool)
+    qc = get_qc(p, config, testname)
 
     return qc
 

--- a/qctests/CoTeDe_location_at_sea_test.py
+++ b/qctests/CoTeDe_location_at_sea_test.py
@@ -7,10 +7,7 @@ def test(p, parameters):
     config   = 'cotede'
     testname = 'location_at_sea'
     
-    try:
-        qc = get_qc(p, config, testname)
-    except:
-        qc = numpy.zeros(1, dtype=bool)
+    qc = get_qc(p, config, testname)
 
     return qc
 

--- a/qctests/CoTeDe_rate_of_change.py
+++ b/qctests/CoTeDe_rate_of_change.py
@@ -7,10 +7,7 @@ def test(p, parameters):
     config   = 'cotede'
     testname = 'rate_of_change'
 
-    try:
-        qc = get_qc(p, config, testname)
-    except:
-        qc = numpy.zeros(1, dtype=bool)
+    qc = get_qc(p, config, testname)
 
     return qc
 

--- a/qctests/CoTeDe_spike.py
+++ b/qctests/CoTeDe_spike.py
@@ -7,10 +7,7 @@ def test(p, parameters):
     config   = 'cotede'
     testname = 'spike'
 
-    try:
-        qc = get_qc(p, config, testname)
-    except:
-        qc = numpy.zeros(1, dtype=bool)
+    qc = get_qc(p, config, testname)
 
     return qc
 

--- a/qctests/CoTeDe_tukey53H_norm.py
+++ b/qctests/CoTeDe_tukey53H_norm.py
@@ -7,10 +7,7 @@ def test(p, parameters):
     config   = 'cotede'
     testname = 'tukey53H_norm'
 
-    try:
-        qc = get_qc(p, config, testname)
-    except:
-        qc = numpy.zeros(1, dtype=bool)
+    qc = get_qc(p, config, testname)
 
     return qc
 

--- a/qctests/EN_background_check.py
+++ b/qctests/EN_background_check.py
@@ -134,7 +134,7 @@ def record_parameters(profile, bgStdLevels, bgevStdLevels, origLevels, ptLevels,
     origlevels = main.pack_array(origLevels)
     ptlevels = main.pack_array(ptLevels)
     bglevels = main.pack_array(bgLevels)
-    query = "INSERT INTO enbackground VALUES(?,?,?,?,?,?);"
+    query = "REPLACE INTO enbackground VALUES(?,?,?,?,?,?);"
     main.dbinteract(query, [profile.uid(), bgstdlevels, bgevstdlevels, origlevels, ptlevels, bglevels])
 
 
@@ -199,7 +199,7 @@ def readENBackgroundCheckAux():
 def loadParameters(parameterStore):
 
     main.dbinteract("DROP TABLE IF EXISTS enbackground")
-    main.dbinteract("CREATE TABLE IF NOT EXISTS enbackground (uid INTEGER, bgstdlevels BLOB, bgevstdlevels BLOB, origlevels BLOB, ptlevels BLOB, bglevels BLOB)")
+    main.dbinteract("CREATE TABLE IF NOT EXISTS enbackground (uid INTEGER PRIMARY KEY, bgstdlevels BLOB, bgevstdlevels BLOB, origlevels BLOB, ptlevels BLOB, bglevels BLOB)")
     parameterStore['enbackground'] = readENBackgroundCheckAux()
 
 

--- a/qctests/EN_spike_and_step_check.py
+++ b/qctests/EN_spike_and_step_check.py
@@ -102,7 +102,7 @@ def run_qc(p, suspect):
 
     # register suspects, if computed, to db
     if suspect:
-        query = "INSERT INTO enspikeandstep VALUES(?,?);"
+        query = "REPLACE INTO enspikeandstep VALUES(?,?);"
         main.dbinteract(query, [p.uid(), main.pack_array(qc)] )
 
     return qc
@@ -203,4 +203,4 @@ def interpolate(depth, shallow, deep, shallowVal, deepVal):
 def loadParameters(parameterStore):
 
     main.dbinteract("DROP TABLE IF EXISTS enspikeandstep")
-    main.dbinteract("CREATE TABLE IF NOT EXISTS enspikeandstep (uid INTEGER, suspect BLOB)")
+    main.dbinteract("CREATE TABLE IF NOT EXISTS enspikeandstep (uid INTEGER PRIMARY KEY, suspect BLOB)")

--- a/qctests/EN_track_check.py
+++ b/qctests/EN_track_check.py
@@ -6,7 +6,7 @@ http://www.metoffice.gov.uk/hadobs/en3/OQCpaper.pdf
 import numpy as np
 import util.main as main
 import util.geo as geo
-import copy, datetime, math, sys, calendar
+import copy, datetime, math, sys, calendar, sqlite3
 
 # module constants
 DistRes = 20000. # meters
@@ -64,12 +64,12 @@ def test(p, parameters):
             EN_track_results[track_rows[i][0]][0] = True
    
     # write all to db
+    result = []
     for i in range(len(track_rows)):
-        result = main.pack_array(EN_track_results[track_rows[i][0]])
-        
-        query = "UPDATE " + sys.argv[1] + " SET en_track_check=? WHERE uid = " + str(track_rows[i][0]) + ";"
+        result.append((main.pack_array(EN_track_results[track_rows[i][0]]), track_rows[i][0]))
 
-        main.dbinteract(query, (result,))
+    query = "UPDATE " + sys.argv[1] + " SET en_track_check=? WHERE uid=?"
+    main.interact_many(query, result)
 
     return EN_track_results[uid]
 

--- a/qctests/ICDC_aqc_01_level_order.py
+++ b/qctests/ICDC_aqc_01_level_order.py
@@ -111,7 +111,7 @@ def level_order(p):
     tr_p = pickle.dumps(tr, -1)
     qc_p = pickle.dumps(qc, -1)
     
-    query = "INSERT INTO icdclevelorder VALUES(?,?,?,?,?,?)"
+    query = "REPLACE INTO icdclevelorder VALUES(?,?,?,?,?,?)"
     main.dbinteract(query, [p.uid(), nlevels, sqlite3.Binary(origlevels_p), sqlite3.Binary(zr_p), sqlite3.Binary(tr_p), sqlite3.Binary(qc_p)])
 
     return p.uid(), nlevels, origlevels, zr, tr, qc
@@ -119,4 +119,4 @@ def level_order(p):
 def loadParameters(parameterStore):
 
     main.dbinteract("DROP TABLE IF EXISTS icdclevelorder")
-    main.dbinteract("CREATE TABLE IF NOT EXISTS icdclevelorder (uid INTEGER, nlevels INTEGER, origlevels BLOB, zr BLOB, tr BLOB, qc BLOB)")
+    main.dbinteract("CREATE TABLE IF NOT EXISTS icdclevelorder (uid INTEGER PRIMARY KEY, nlevels INTEGER, origlevels BLOB, zr BLOB, tr BLOB, qc BLOB)")

--- a/qctests/ICDC_aqc_09_local_climatology_check.py
+++ b/qctests/ICDC_aqc_09_local_climatology_check.py
@@ -51,7 +51,7 @@ def test(p, parameters):
         return defaultqc
     
     # parameters
-    nc = parameters['nc']
+    nc = Dataset('data/climatological_t_median_and_amd_for_aqc.nc', 'r')
     
     # Get range.
     ranges = get_climatology_range(nlevels, z, lat, lon, p.month(), nc)
@@ -126,7 +126,4 @@ def get_climatology_range(nlevels, z, lat, lon, month, nc):
 
     return tmin, tmax
 
-def loadParameters(parameterStore):
-
-  parameterStore['nc'] = Dataset('data/climatological_t_median_and_amd_for_aqc.nc', 'r')
 

--- a/tests/EN_track_validation.py
+++ b/tests/EN_track_validation.py
@@ -84,8 +84,12 @@ class TestClass():
         speeds, angles = qctests.EN_track_check.calculateTraj(rows)
 
         assert numpy.array_equal(speeds, trueSpeeds)
-        assert numpy.array_equal(angles, trueAngles)
-
+        assert angles[0] is None
+        assert angles[5] is None
+        for i in range(1, len(angles)-1):
+            assert abs(angles[i] - trueAngles[i]) < 0.000001
+        
+ 
     def meanSpeed_test(self):
         '''
         make sure mean speed rejects speeds that are too fast

--- a/tests/ICDC_aqc_09_local_climatology_check_validation.py
+++ b/tests/ICDC_aqc_09_local_climatology_check_validation.py
@@ -12,8 +12,6 @@ class TestClass():
 
     parameters = {}
     
-    ICDC_lc.loadParameters(parameters)
-
     def setUp(self):
         # refresh this table every test
         ICDC.loadParameters(self.parameters)
@@ -27,6 +25,7 @@ class TestClass():
         '''
 
         lines = data.splitlines()
+        nc = Dataset('data/climatological_t_median_and_amd_for_aqc.nc', 'r')
         for i, line in enumerate(lines):
             if line[0:2] == 'HH':
                 header  = line.split()
@@ -65,7 +64,7 @@ class TestClass():
                                                               lat, 
                                                               lon,
                                                               p.month(), 
-                                                              self.parameters['nc'])
+                                                              nc)
 
                 assert np.max(np.abs(tmin - climmin)) < 0.001, 'TMIN failed for profile with header ' + line
                 assert np.max(np.abs(tmax - climmax)) < 0.001, 'TMAX failed for profile with header ' + line


### PR DESCRIPTION
This PR presents a number of modifications to out sqlite3-backed implementation, both to better support parallelization, and address some other issues that became apparent while resolving this:

 - The parallelization problems we were facing were due to difficulties with python's netCDF package in parallel read environments (see https://github.com/Unidata/netcdf4-python/issues/640, https://github.com/Unidata/netcdf4-python/issues/437). Reading `ICDC_09`'s parameter file in the child process resolves this issue.
 - Very generous tolerances are allowed for database connection timeouts (60 seconds) and retries (100). This is necessary to accommodate sqlite's single-writer behavior.
 - Implements a simple logging infrastructure. Each profile will persist a separate log of its stdout and stderr streams, for easier debugging and auditing of runs. Previous to this, errors produced in the `multiprocessing` pool were getting suppressed or lost.
 - CoTeDe wrappers no longer suppress errors from that suite, but instead log them in the logging files described above. 
 - `uid` is explicitly specified as the primary key for all tables that use it; this results in a dramatic speed-up (factor of 2-3 on @s-good's 10k profile sample when running on my laptop).
 - More care is taken to ensure duplicate entries aren't registered in any tables, by use of `REPLACE INTO` rather than `INSERT INTO`.
 - Haversine angle tolerances are permitted in `EN_track`'s tests to match the direct tests of the angle calculation function in the `util/geo` package.

@s-good, once this passes travis I'm going to merge it into `no-global`; provided that it produces the expected result on your 10k sample profiles analyzed in parallel (it does for me, but do please confirm independently), then `no-global` should finally be ready for merge to `master`.