### PR TITLE
protect against duplicate profiles when building db

### DIFF
--- a/build-db.py
+++ b/build-db.py
@@ -57,6 +57,9 @@ if len(sys.argv) == 3:
 
         # check for duplicate profiles in raw data
         if p['uid'] in uids: 
+            print 'Skipping duplicate UID: ', str(p['uid'])
+            print 'File:', sys.argv[1]
+            print 'File position (bytes):', str(start)
             if profile.is_last_profile_in_file(fid) == True:
                 break
             else:

--- a/build-db.py
+++ b/build-db.py
@@ -41,7 +41,7 @@ if len(sys.argv) == 3:
 
     # populate table from wod-ascii data
     fid = open(sys.argv[1])
-
+    uids = []
     while True:
         # extract profile as wodpy object and raw text
         start = fid.tell()
@@ -54,6 +54,14 @@ if len(sys.argv) == 3:
         # set up dictionary for populating query string
         p = profile.npdict()
         p['raw'] = "'" + raw + "'"
+
+        # check for duplicate profiles in raw data
+        if p['uid'] in uids: 
+            if profile.is_last_profile_in_file(fid) == True:
+                break
+            else:
+                continue
+        uids.append(p['uid'])
 
         # Require temperature data, otherwise skip.
         skip = False


### PR DESCRIPTION
Now that we use uid as a formal primary key when building our initial database in `build-db.py`, we must deal with the situation where a duplicate profile appears in the raw wod-ascii data (as one does in my copy of the full quota set). Here we keep track of what uids have been previously written to the database, and skip any subsequent repeats.