### PR TITLE
protect against missing data when summarizing true qc decisions

### DIFF
--- a/util/dbutils.py
+++ b/util/dbutils.py
@@ -28,7 +28,7 @@ def parse(results):
 def summarize_truth(levels):
     'given an array of originator qc decisions, return true iff any of the levels are flagged'
 
-    return sum(levels >= 3) >= 1
+    return numpy.sum(levels >= 3) >= 1
 
 def parse_truth(results):
 


### PR DESCRIPTION
Turns out that python's built-in `sum` and numpy's summation function return different results when summing up masked arrays with some-but-not-all the entries masked:

```
In [43]: m = np.ma.array([3,4,10], mask=[True, True, False])

In [45]: sum(m)
Out[45]: masked

In [46]: np.sum(m)
Out[46]: 10
```

This was messing up our assessment of whether there were any true QC flags in our `dbutils` package.