### PR TITLE
Handling temperature 99 error codes

### DIFF
--- a/build-db.py
+++ b/build-db.py
@@ -73,8 +73,13 @@ if len(sys.argv) == 3:
         if np.sum(profile.t().mask == False) == 0:
             skip = True
         # Require truth data, otherwise skip
+        # also, register any level with temperature ~99 as QC code 99 in the truth array
         try:
-            p['truth'] = main.pack_array(profile.t_level_qc(originator=True))
+            truth = p.t_level_qc(originator=True)
+            for i,temp in enumerate(p.t()):
+                if temp > 99 and temp < 100:
+                    truth[i] = 99
+            p['truth'] = main.pack_array(truth)
         except:
             skip = True
         if skip and profile.is_last_profile_in_file(fid) == True:

--- a/util/dbutils.py
+++ b/util/dbutils.py
@@ -26,9 +26,9 @@ def parse(results):
     return results.apply(unpack_qc).apply(summarize)
 
 def summarize_truth(levels):
-    'given an array of originator qc decisions, return true iff any of the levels are flagged'
+    'given an array of originator qc decisions, return true iff any of the levels are flagged, ignoring t=99 levels'
 
-    return numpy.sum(levels >= 3) >= 1
+    return numpy.sum([x >= 3 and x < 99 for x in levels ]) >= 1
 
 def parse_truth(results):
 

--- a/util/main.py
+++ b/util/main.py
@@ -19,7 +19,7 @@ def importQC(dir):
 
 def catchFlags(profile):
   '''
-  In some IQuOD datasets temperature values of 99.9 are special values to
+  In some IQuOD datasets temperature values of 99.9 or 99.99 are special values to
   signify not to use the data value. These are flagged here so they are not
   sent to the quality control programs for testing.
   '''
@@ -28,7 +28,7 @@ def catchFlags(profile):
   for i in range(profile.n_levels()):
       if profile.profile_data[i]['variables'][index]['Missing']:
           continue
-      if profile.profile_data[i]['variables'][index]['Value'] == 99.9:
+      if profile.profile_data[i]['variables'][index]['Value'] >= 99.9 and profile.profile_data[i]['variables'][index]['Value'] < 100:
           profile.profile_data[i]['variables'][index]['Missing'] = True
 
 def checkQCTestRequirements(checks):

--- a/util/main.py
+++ b/util/main.py
@@ -28,7 +28,7 @@ def catchFlags(profile):
   for i in range(profile.n_levels()):
       if profile.profile_data[i]['variables'][index]['Missing']:
           continue
-      if profile.profile_data[i]['variables'][index]['Value'] >= 99.9 and profile.profile_data[i]['variables'][index]['Value'] < 100:
+      if profile.profile_data[i]['variables'][index]['Value'] >= 99 and profile.profile_data[i]['variables'][index]['Value'] < 100:
           profile.profile_data[i]['variables'][index]['Missing'] = True
 
 def checkQCTestRequirements(checks):


### PR DESCRIPTION
It seems that 99.99, in addition to 99.9, has been used as a mask; see UIDs 66424634, 66424635, 66424645, 66425567, 66425571 for example. The UID's mentioned make up about half the false positives in the optimal point of the ROC curve I'm currently looking at, so this seems impactful; @s-good let me know if a temperature of 99.99 is indeed to be masked as I assume, or if it means something more nuanced.