### PR TITLE
Sample construction, truth summarization and ROC calculation and plotting

### DIFF
--- a/AutoQC.py
+++ b/AutoQC.py
@@ -1,9 +1,8 @@
 from wodpy import wod
-import pickle, psycopg2, sys, os, calendar, time
+import pickle, sys, os, calendar, time
 import numpy as np
 import util.main as main
 from multiprocessing import Pool
-
 
 def run(test, profiles, parameters):
   '''

--- a/analyse-results.py
+++ b/analyse-results.py
@@ -1,4 +1,4 @@
-import json
+import json, pandas
 import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
@@ -33,11 +33,31 @@ def find_roc(table,
     '''
 
     # Read data from database into a pandas data frame.
-    df        = dbutils.db_to_df(sys.argv[1], 
+    df        = dbutils.db_to_df(sys.argv[1],
                                  filter_on_wire_break_test=filter_on_wire_break_test,
                                  n_to_extract=n_profiles_to_analyse)
-    testNames = df.columns[1:].values.tolist()
-    if verbose: 
+
+    # mark chosen profiles as part of the training set 
+    all_uids = main.dbinteract('SELECT uid from ' + sys.argv[1] + ';')
+    for uid in all_uids:
+        uid = uid[0]
+        is_training = int(uid in df['uid'].astype(int).as_matrix())
+        query = "UPDATE " + sys.argv[1] + " SET training=" + str(is_training) + " WHERE uid=" + str(uid) + ";"
+        main.dbinteract(query)
+
+    # drop nondiscriminating tests
+    nondiscrim = []
+    cols = list(df.columns)
+    for c in cols:
+        if len(pandas.unique(df[c])) == 1:
+            nondiscrim.append(c)
+    cols = [t for t in cols if t not in nondiscrim]
+    df = df[cols]
+    print list(df)
+
+    testNames = df.columns[2:].values.tolist()
+
+    if verbose:
         print 'Number of profiles from database was: ', len(df.index)
         print 'Number of quality checks from database was: ', len(testNames)
 
@@ -56,7 +76,7 @@ def find_roc(table,
         for reversal in reverselist:
             results = df[testname].as_matrix() != reversal
             tpr, fpr, fnr, tnr = main.calcRates(results, truth)
-            if tpr > 0.0: 
+            if tpr > 0.0:
                 tests.append(results)
                 if reversal:
                     addtext = 'r'
@@ -82,7 +102,7 @@ def find_roc(table,
 
                 results = np.logical_and(tests[i], tests[j])
                 tpr, fpr, fnr, tnr = main.calcRates(results, truth)
-                if tpr > 0.0: 
+                if tpr > 0.0:
                     tests.append(results)
                     tprs.append(tpr)
                     fprs.append(fpr)
@@ -170,4 +190,4 @@ if __name__ == '__main__':
         find_roc(sys.argv[1], n_profiles_to_analyse=sys.argv[2])
     else:
         print 'Usage - python analyse_results.py tablename [number of profiles to read from database]'
-         
+

--- a/analyse-results.py
+++ b/analyse-results.py
@@ -184,10 +184,8 @@ def find_roc(table,
 
 if __name__ == '__main__':
 
-    if len(sys.argv) == 2:
-        find_roc(sys.argv[1])
-    elif len(sys.argv) == 3:
+    if len(sys.argv) == 3:
         find_roc(sys.argv[1], n_profiles_to_analyse=sys.argv[2])
     else:
-        print 'Usage - python analyse_results.py tablename [number of profiles to read from database]'
+        print 'Usage - python analyse_results.py tablename <number of profiles to train ROC curve on>'
 

--- a/build-db.py
+++ b/build-db.py
@@ -102,7 +102,8 @@ if len(sys.argv) == 3:
     uids = []
     good = 0
     bad = 0
-    while True:
+    #while True:
+    for qq in range(100):
         # extract profile as wodpy object and raw text
         start = fid.tell()
         profile = wod.WodProfile(fid)

--- a/build-db.py
+++ b/build-db.py
@@ -17,9 +17,7 @@ if len(sys.argv) == 3:
     testNames.sort()
 
     # set up our table
-    query = "DROP TABLE IF EXISTS " + sys.argv[2] + ";"
-    cur.execute(query)
-    query = "CREATE TABLE " + sys.argv[2] + """(
+    query = "CREATE TABLE IF NOT EXISTS " + sys.argv[2] + """(
                 raw text,
                 truth BLOB,
                 uid integer PRIMARY KEY,

--- a/build-db.py
+++ b/build-db.py
@@ -102,8 +102,7 @@ if len(sys.argv) == 3:
     uids = []
     good = 0
     bad = 0
-    #while True:
-    for qq in range(100):
+    while True:
         # extract profile as wodpy object and raw text
         start = fid.tell()
         profile = wod.WodProfile(fid)

--- a/plot-roc.py
+++ b/plot-roc.py
@@ -1,0 +1,122 @@
+import pandas, sqlite3, json, calendar, time, os, sys
+import util.dbutils as dbutils
+import util.main as main
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import pylab
+
+figdir = "roc-figs-" + str(calendar.timegm(time.gmtime()))
+
+def generateROC(file='roc.json', maxfpr=0.1):
+    '''
+    return a function that accepts a dataabse row and evaluates the roc function described in the input, 
+    cut off at a max false positive rate of maxfpr percent.
+    '''
+
+    with open(file) as json_data:
+        d = json.load(json_data)
+
+    # find fpr cutoff:
+    cut = 0
+    for i in range(len(d['fpr'])):
+        if d['fpr'][i] < maxfpr:
+            cut = i
+        else:
+            break
+
+    tests = d['tests'][0:cut+1]
+
+    def e(row):
+        result = False
+        for t in tests:
+            qcs = t.split('&')
+            term = True
+            for qc in qcs:
+                term = term and row[qc]
+            result = result or term
+        return result
+
+    return e
+
+# going to want per-level truth info for flagging levels in plots
+def unpack_truth(results):
+
+    return results.apply(dbutils.unpack_qc)
+
+def plotRow(row):
+    p = main.text2wod(row['raw'][1:-1])
+    fig = plt.figure()
+    ax1 = fig.add_subplot(111)
+    im = ax1.scatter(p.z(),p.t(), c=row['leveltruth'][0], norm=matplotlib.colors.Normalize(vmin=1, vmax=10), cmap='tab10')
+    fig.colorbar(im, ax=ax1)
+    plt.xlabel('Depth [m]')
+    plt.ylabel('Temperature [C]')
+    plt.title(str(p.uid()))
+    range = plt.ylim()
+    plt.ylim(max(-10, range[0]), min(40, range[1]))
+    range = plt.ylim()
+    dom = plt.xlim()
+    plt.xlim(max(-10, dom[0]), min(10000, dom[1]))
+    dom = plt.xlim()
+    xmargin = (dom[1] - dom[0])*0.7 + dom[0]
+    yspace = (range[1] - range[0])*0.05
+    ymargin = (range[1] - range[0])*0.95 + range[0]
+    plt.text(xmargin,ymargin - 2*yspace, 'Lat: ' + str(p.latitude()))
+    plt.text(xmargin,ymargin - 3*yspace, 'Long: ' + str(p.longitude()))
+    plt.text(xmargin,ymargin - 4*yspace, 'Probe: ' + str(p.probe_type()))
+    plt.text(xmargin,ymargin - 5*yspace, 'Date: ' + str(p.year()) + '/' + str(p.month()) + '/' + str(p.day())    )
+    plt.text(xmargin,ymargin - 6*yspace, 'Originator: ' + str(p.originator_flag_type()))
+    if row['Truth'] and row['roc']:
+        dir = figdir+'/TP/'
+    elif row['Truth'] and not row['roc']:
+        dir = figdir+'/FN/'
+    elif not row['Truth'] and not row['roc']:
+        dir = figdir+'/TN/'
+    elif not row['Truth'] and row['roc']:
+        dir = figdir+'/FP/'
+    pylab.savefig(dir + str(p.uid()) + '.png', bbox_inches='tight')
+    plt.close()
+
+def plot_roc():
+
+    # get qc tests
+    testNames = main.importQC('qctests')
+
+    # connect to database
+    conn = sqlite3.connect('iquod.db', isolation_level=None)
+    cur = conn.cursor()
+
+    # extract matrix of test results and true flags into a dataframe
+    query = 'SELECT truth, raw, ' + ','.join(testNames) + ' FROM ' + sys.argv[1] + ' WHERE training=0;'
+    cur.execute(query)
+    rawresults = cur.fetchall()
+    df = pandas.DataFrame(rawresults).astype('str')
+    df.columns = ['Truth', 'raw'] + testNames
+
+    # unpack truth and qc data
+    truth = df[['Truth']].apply(unpack_truth).values.tolist()
+    df = df.assign(leveltruth=pandas.Series(truth))
+    df[['Truth']] = df[['Truth']].apply(dbutils.parse_truth)
+    for t in testNames:
+        df[[t]] = df[[t]].apply(dbutils.parse)
+
+    # prepare ROC function
+    assessROC = generateROC()
+    df['roc'] = df.apply(assessROC, axis=1)
+
+    # set up dirs for figures
+    os.makedirs(figdir)
+    os.makedirs(figdir + '/FP')
+    os.makedirs(figdir + '/FN')
+    os.makedirs(figdir + '/TP')
+    os.makedirs(figdir + '/TN')
+
+    df.apply(plotRow, axis=1)
+
+if __name__ == '__main__':
+
+    if len(sys.argv) == 2:
+        plot_roc()
+    else:
+        print 'Usage - python plot-roc.py tablename'


### PR DESCRIPTION
This PR contains a number of infrastructural odds and ends developed while analyzing QuOTA:

`build-db.py`
 - adds a 'training' column into the db to keep track of which profiles are being used for algorithm training
 - filters out (in addition to previous filters):
     - profiles expressed in standard levels
     - profiles with depth approx 0 for all levels (lots of these in quota)
     - profiles with corrupt or missing originator temperature qc decisions at any level that has a nominally valid temperature reading

`db-utils.py`
 - Add uid to dataframe in `db_to_df`, and explicitly randomize selection when unpacking less than the whole database.
 - `summarize_truth` makes sure not to count masked qc levels when summarizing per-level flags; addresses edge case where a masked level would be cast to nan, summed with legitimately flagged levels resulting in a sum of nan, which returns false when compared to zero, spoofing a clean profile.

`analyze-results.py`
 - now requires specifying a number of profiles to examine, and marks these with a `1` in the `training` column of the main database. This is so we can develop a ROC curve on a subset of the data, then test its performance on the remainder of the data so we don't get artificially good ROC curve performance estimates.
 - explicitly drop qc tests that return all true or all false

`plot-roc.py`
 - new script to plot all the profiles in the database, sorted by [true | false][positive | negative], with flags defined by a point on the ROC curve specified in `roc.json`. Default point is highest TP not exceeding 0.1% FP.