### PR TITLE
more thorough wire break test

### DIFF
--- a/qctests/CSIRO_wire_break.py
+++ b/qctests/CSIRO_wire_break.py
@@ -1,9 +1,16 @@
 """
-Implements the wire break test of DOI: 10.1175/JTECHO539.1
-All questionable features result in a flag, in order to minimize false negatives 
+Implements the wire break test of https://github.com/BecCowley/Mquest/blob/083b9a3dc7ec9076705aca0e90bcb500d241be03/GUI/detectwirebreak.m
 """
 
 import numpy
+
+def istight(t, thresh=0.1):
+    # given a temperature profile, return an array of bools
+    # true = this level is within thresh of both its neighbors
+    gaps = numpy.absolute(numpy.diff(t))
+    left = numpy.append(gaps,0)
+    right = numpy.insert(gaps,0,0)
+    return (left<thresh) & (right<thresh)
 
 def test(p, parameters):
     """
@@ -12,43 +19,23 @@ def test(p, parameters):
     passed the check and True where it failed.
     """
 
-    # Get temperature values from the profile.
     t = p.t()
-    d = p.z()
 
-    # initialize qc as a bunch of falses;
+    # initialize qc as a bunch of falses:
     qc = numpy.zeros(len(t.data), dtype=bool)
 
     # only meaningful for XBT data
     if p.probe_type() != 2:
         return qc
 
-    # check for gaps in data
-    isTemperature = (t.mask==False)
-    isDepth = (d.mask==False)
-    isData = isTemperature & isDepth
+    no_wb = numpy.where( (t >= -2.4) & (t <= 32) & istight(t) )[0]
 
-    # wire breaks at bottom of profile;
-    # don't bother continuing if the bottom level doesn't look like a wb
-    if isTemperature[-1] and (t.data[-1] < -2.8 or t.data[-1] > 36):
-           qc[-1] = True
+    if len(no_wb) > 0:
+        last_good = no_wb[-1]
+        qc = numpy.append(numpy.zeros(last_good + 1, dtype=bool), numpy.ones(len(t) - last_good - 1, dtype=bool))
     else:
-        return qc
-
-    i = 2
-    while i<len(t):
-        # extreme temperatures at end
-        if isTemperature[-1*i] and (t.data[-1*i] < -2.8 or t.data[-1*i] > 36):
-            qc[-1*i] = True
-        # hard gradient between physical data and wire break
-        elif isData[-1*i] and isData[-1*(i+1)]:
-            grad = abs((t.data[-1*i] - t.data[-1*(i+1)]) / (d.data[-1*i] - d.data[-1*(i+1)]))
-            qc[-1*i] = grad > 0.5
-
-        # break out as soon as wire break behavior ends:
-        if not qc[-1*i]:
-            break
-
-        i+=1
+        qc = numpy.ones(len(t.data), dtype=bool)
 
     return qc
+
+

--- a/qctests/CSIRO_wire_break.py
+++ b/qctests/CSIRO_wire_break.py
@@ -14,18 +14,41 @@ def test(p, parameters):
 
     # Get temperature values from the profile.
     t = p.t()
-    # is this an xbt?
-    isXBT = p.probe_type() == 2
+    d = p.z()
 
     # initialize qc as a bunch of falses;
     qc = numpy.zeros(len(t.data), dtype=bool)
 
+    # only meaningful for XBT data
+    if p.probe_type() != 2:
+        return qc
+
     # check for gaps in data
     isTemperature = (t.mask==False)
+    isDepth = (d.mask==False)
+    isData = isTemperature & isDepth
 
-    # wire breaks at bottom of profile:
-    if isTemperature[-1] and isXBT:
-        if t.data[-1] < -2.8 or t.data[-1] > 36:
-            qc[-1] = True
+    # wire breaks at bottom of profile;
+    # don't bother continuing if the bottom level doesn't look like a wb
+    if isTemperature[-1] and (t.data[-1] < -2.8 or t.data[-1] > 36):
+           qc[-1] = True
+    else:
+        return qc
+
+    i = 2
+    while i<len(t):
+        # extreme temperatures at end
+        if isTemperature[-1*i] and (t.data[-1*i] < -2.8 or t.data[-1*i] > 36):
+            qc[-1*i] = True
+        # hard gradient between physical data and wire break
+        elif isData[-1*i] and isData[-1*(i+1)]:
+            grad = abs((t.data[-1*i] - t.data[-1*(i+1)]) / (d.data[-1*i] - d.data[-1*(i+1)]))
+            qc[-1*i] = grad > 0.5
+
+        # break out as soon as wire break behavior ends:
+        if not qc[-1*i]:
+            break
+
+        i+=1
 
     return qc

--- a/tests/CSIRO_wire_break_validation.py
+++ b/tests/CSIRO_wire_break_validation.py
@@ -8,63 +8,49 @@ def test_CSIRO_wire_break():
     '''
     Spot-check the nominal behavior of the CSIRO wire break test.
     '''
-   
-    # bottom level tests
 
     # too cold at the bottom of xbt profile
-    p = util.testingProfile.fakeProfile([0,0,-20], [10,20,30], probe_type=2) 
+    p = util.testingProfile.fakeProfile([-2.399,-2.399,-2.4001], [10,20,30], probe_type=2) 
     qc = qctests.CSIRO_wire_break.test(p, None)
     truth = numpy.zeros(3, dtype=bool)
     truth[2] = True
     assert numpy.array_equal(qc, truth), 'failed to flag too-cold temperature at bottom of profile'
 
     # too hot at bottom of xbt profile
-    p = util.testingProfile.fakeProfile([0,0,100], [10,20,30], probe_type=2) 
+    p = util.testingProfile.fakeProfile([31.99,31.99,32.001], [10,20,30], probe_type=2) 
     qc = qctests.CSIRO_wire_break.test(p, None)
     truth = numpy.zeros(3, dtype=bool)
     truth[2] = True
     assert numpy.array_equal(qc, truth), 'failed to flag too-hot temperature at bottom of profile'
 
     # right on border - no flag
-    p = util.testingProfile.fakeProfile([0,0,-2.8], [10,20,30], probe_type=2) 
+    p = util.testingProfile.fakeProfile([-2.399,-2.399,-2.4], [10,20,30], probe_type=2) 
     qc = qctests.CSIRO_wire_break.test(p, None)
     truth = numpy.zeros(3, dtype=bool)
-    truth[2] = False
+    print qc
+    print truth
     assert numpy.array_equal(qc, truth), 'flagged marginally cold temperature at bottom of profile'
 
-    p = util.testingProfile.fakeProfile([0,0,36], [10,20,30], probe_type=2) 
+    p = util.testingProfile.fakeProfile([31.99,31.99,32], [10,20,30], probe_type=2) 
     qc = qctests.CSIRO_wire_break.test(p, None)
     truth = numpy.zeros(3, dtype=bool)
-    truth[2] = False
     assert numpy.array_equal(qc, truth), 'flagged marginally hot temperature at bottom of profile'
 
     # don't flag if not an xbt
     p = util.testingProfile.fakeProfile([0,0,-100], [10,20,30], probe_type=1) 
     qc = qctests.CSIRO_wire_break.test(p, None)
     truth = numpy.zeros(3, dtype=bool)
-    truth[2] = False
     assert numpy.array_equal(qc, truth), 'flagged non-xbt profile'
 
     # don't flag if not at bottom of profile
-    p = util.testingProfile.fakeProfile([0,-100,0], [10,20,30], probe_type=2) 
+    p = util.testingProfile.fakeProfile([0,32.01,31.99], [10,20,30], probe_type=2) 
     qc = qctests.CSIRO_wire_break.test(p, None)
     truth = numpy.zeros(3, dtype=bool)
-    truth[1] = False
-    assert numpy.array_equal(qc, truth), "flagged cold temperature that wasn't at bottom of profile"   
+    assert numpy.array_equal(qc, truth), "flagged hot temperature that wasn't at bottom of profile"    
 
-    # transition tests 
-
-    p = util.testingProfile.fakeProfile([10,10,20,50,50], [1,2,3,4,5], probe_type=2) 
+    # flag both sides of a gap
+    p = util.testingProfile.fakeProfile([9,9,10], [10,20,30], probe_type=2) 
     qc = qctests.CSIRO_wire_break.test(p, None)
-    truth = numpy.asarray([False, False, True, True, True])
-    assert numpy.array_equal(qc, truth), "misflagged gradient (warm)"
-
-    p = util.testingProfile.fakeProfile([10,10,-20,-50,-50], [1,2,3,4,5], probe_type=2) 
-    qc = qctests.CSIRO_wire_break.test(p, None)
-    truth = numpy.asarray([False, False, True, True, True])
-    assert numpy.array_equal(qc, truth), "misflagged gradient (cold)"
-
-    p = util.testingProfile.fakeProfile([10,10,20,30,30], [1,2,3,4,5], probe_type=2) 
-    qc = qctests.CSIRO_wire_break.test(p, None)
-    truth = truth = numpy.zeros(5, dtype=bool)
-    assert numpy.array_equal(qc, truth), "flagged gradient when final level didn't look like a wire break"         
+    truth = numpy.ones(3, dtype=bool)
+    truth[0] = False
+    assert numpy.array_equal(qc, truth), "should flag both sides of a gap"

--- a/tests/CSIRO_wire_break_validation.py
+++ b/tests/CSIRO_wire_break_validation.py
@@ -8,6 +8,8 @@ def test_CSIRO_wire_break():
     '''
     Spot-check the nominal behavior of the CSIRO wire break test.
     '''
+   
+    # bottom level tests
 
     # too cold at the bottom of xbt profile
     p = util.testingProfile.fakeProfile([0,0,-20], [10,20,30], probe_type=2) 
@@ -48,4 +50,21 @@ def test_CSIRO_wire_break():
     qc = qctests.CSIRO_wire_break.test(p, None)
     truth = numpy.zeros(3, dtype=bool)
     truth[1] = False
-    assert numpy.array_equal(qc, truth), "flagged cold temperature that wasn't at bottom of profile"    
+    assert numpy.array_equal(qc, truth), "flagged cold temperature that wasn't at bottom of profile"   
+
+    # transition tests 
+
+    p = util.testingProfile.fakeProfile([10,10,20,50,50], [1,2,3,4,5], probe_type=2) 
+    qc = qctests.CSIRO_wire_break.test(p, None)
+    truth = numpy.asarray([False, False, True, True, True])
+    assert numpy.array_equal(qc, truth), "misflagged gradient (warm)"
+
+    p = util.testingProfile.fakeProfile([10,10,-20,-50,-50], [1,2,3,4,5], probe_type=2) 
+    qc = qctests.CSIRO_wire_break.test(p, None)
+    truth = numpy.asarray([False, False, True, True, True])
+    assert numpy.array_equal(qc, truth), "misflagged gradient (cold)"
+
+    p = util.testingProfile.fakeProfile([10,10,20,30,30], [1,2,3,4,5], probe_type=2) 
+    qc = qctests.CSIRO_wire_break.test(p, None)
+    truth = truth = numpy.zeros(5, dtype=bool)
+    assert numpy.array_equal(qc, truth), "flagged gradient when final level didn't look like a wire break"         


### PR DESCRIPTION
It occurs to me that `util.dbutils.db_to_df`'s `filter_on_wire_break` option seems to assume that `CSIRO_wire_break` test flags all levels that are affected by a wire break; I'm not sure that it does. Most profiles flagged by the wire break test look qualitatively like:

![3990](https://user-images.githubusercontent.com/1896943/36882607-e766f83c-1da2-11e8-85b3-a824f09c87b6.png)

But [the wire break reference](https://journals.ametsoc.org/doi/full/10.1175/JTECHO539.1) and our qc test only check the very last level - meaning that the db util is only filtering out, at most, the last level of a profile. Is that really what we want, or do we want to filter out all the red points in the above figure? (the unlabeled color scale is originator qc code).

This PR tries to flag all such points at the end of a profile by flagging:
 - all the levels in a consecutive run from the end that fall outside of -2.8<t<36
 - all consecutive levels shallower than this run where the gradient from the next-shallower level is > 0.5 deg C / m in magnitude.

This is somewhat arbitrarily constructed - @s-good please let me know if I've misread something entirely, and also how we can make this a little more precise. Also before we merge, I'm going to run this over a few 10's of thousands of profiles just to check for edge cases.