### PR TITLE
precompute pressures in en_background

### DIFF
--- a/qctests/EN_background_check.py
+++ b/qctests/EN_background_check.py
@@ -73,7 +73,8 @@ def run_qc(p, parameters):
     isData = isTemperature & isDepth
 
     # prep pressures ahead of time
-    pressures = gsw.p_from_z(-z, p.latitude())
+    depth = np.ma.filled(z,30000)
+    pressures = gsw.p_from_z(-depth, p.latitude())
 
     # Use the EN_spike_and_step_check to find suspect values.
     suspect = EN_spike_and_step_check.test(p, parameters, suspect=True)


### PR DESCRIPTION
By transforming depths to pressures for every level in the profile all at once in `en_background`, we can take better advantage of `gsw`'s optimizations (it's really quite well written). Try the following sketch to see an illustration of this:

```
import gsw, numpy
from timeit import default_timer as timer

d = numpy.array(range(2000))
lat = 0

start = timer()
for z in d:
    gsw.p_from_z(-z, lat)
end = timer()
print end-start


start = timer()
gsw.p_from_z(-d, lat)
end = timer()
print end-start
```

As usual, @s-good let me know what you think.