### PR TITLE
dont flag single level profiles in EN_increasing_depth

### DIFF
--- a/qctests/EN_increasing_depth_check.py
+++ b/qctests/EN_increasing_depth_check.py
@@ -61,10 +61,6 @@ def run_qc(p, parameters):
         uid = p.uid()
         return qc
 
-    # Now check for inconsistencies in the depth levels.
-    comp       = np.ndarray((n, n), dtype=int)
-    currentMax = 1
-
     # initialize matrix
     # Comp gets set to 1 if there is not an increase in depth.
     rows = []

--- a/qctests/EN_increasing_depth_check.py
+++ b/qctests/EN_increasing_depth_check.py
@@ -46,7 +46,11 @@ def run_qc(p, parameters):
     # Initialize qc array.
     qc = np.zeros(n, dtype=bool)
 
-    # don't flag single-level profiles
+    # Basic check on each level.
+    qc[d < 0]     = True
+    qc[d > 11000] = True
+
+    # don't perform more sophisticated tests for single-level profiles
     if n == 1:
         return qc
 
@@ -56,10 +60,6 @@ def run_qc(p, parameters):
         qc = np.ones(n, dtype=bool)
         uid = p.uid()
         return qc
-
-    # Basic check on each level.
-    qc[d < 0]     = True
-    qc[d > 11000] = True
 
     # Now check for inconsistencies in the depth levels.
     comp       = np.ndarray((n, n), dtype=int)

--- a/qctests/EN_increasing_depth_check.py
+++ b/qctests/EN_increasing_depth_check.py
@@ -46,6 +46,10 @@ def run_qc(p, parameters):
     # Initialize qc array.
     qc = np.zeros(n, dtype=bool)
 
+    # don't flag single-level profiles
+    if n == 1:
+        return qc
+
     # if all the depths are the same, flag all levels and finish immediately
     most_common_depth = Counter(d.data).most_common(1)
     if most_common_depth[0][1] == len(d.data):


### PR DESCRIPTION
@s-good, this is what I mentioned to you over email earlier today - this simple fix reflects what I ran to get the results we'll likely present in Oostende. You mentioned checking single level profiles for depths >=0, which I will have a look at presently, as well as adding some unit tests for this edge case.