### PR TITLE
Best QC set using at least one from each type of test

### DIFF
--- a/analyse-results.py
+++ b/analyse-results.py
@@ -289,5 +289,5 @@ if __name__ == '__main__':
     elif len(sys.argv) == 4:
         find_roc(sys.argv[1], n_profiles_to_analyse=sys.argv[2], enforce_types_of_check=False, n_combination_iterations=1)
     else:
-        print 'Usage - python analyse_results.py tablename <number of profiles to train ROC curve on>'
+        print 'Usage - python analyse_results.py tablename <number of profiles to train ROC curve on> <optional character or number to indicate that we run one test combination iteration and no enforcing of groups>'
 

--- a/analyse-results.py
+++ b/analyse-results.py
@@ -102,12 +102,12 @@ def find_roc(table,
         print 'Number of quality checks to process is: ', len(testNames)
 
     # mark chosen profiles as part of the training set 
-#    all_uids = main.dbinteract('SELECT uid from ' + sys.argv[1] + ';')
-#    for uid in all_uids:
-#        uid = uid[0]
-#        is_training = int(uid in df['uid'].astype(int).as_matrix())
-#        query = "UPDATE " + sys.argv[1] + " SET training=" + str(is_training) + " WHERE uid=" + str(uid) + ";"
-#        main.dbinteract(query)
+    all_uids = main.dbinteract('SELECT uid from ' + sys.argv[1] + ';')
+    for uid in all_uids:
+        uid = uid[0]
+        is_training = int(uid in df['uid'].astype(int).as_matrix())
+        query = "UPDATE " + sys.argv[1] + " SET training=" + str(is_training) + " WHERE uid=" + str(uid) + ";"
+        main.dbinteract(query)
 
     # Convert to numpy structures and make inverse versions of tests if required.
     # Any test with true positive rate of zero is discarded.

--- a/analyse-results.py
+++ b/analyse-results.py
@@ -107,12 +107,12 @@ def find_roc(table,
         print 'Number of quality checks to process is: ', len(testNames)
 
     # mark chosen profiles as part of the training set 
-#    all_uids = main.dbinteract('SELECT uid from ' + sys.argv[1] + ';')
-#    for uid in all_uids:
-#        uid = uid[0]
-#        is_training = int(uid in df['uid'].astype(int).as_matrix())
-#        query = "UPDATE " + sys.argv[1] + " SET training=" + str(is_training) + " WHERE uid=" + str(uid) + ";"
-#        main.dbinteract(query)
+    all_uids = main.dbinteract('SELECT uid from ' + sys.argv[1] + ';')
+    for uid in all_uids:
+        uid = uid[0]
+        is_training = int(uid in df['uid'].astype(int).as_matrix())
+        query = "UPDATE " + sys.argv[1] + " SET training=" + str(is_training) + " WHERE uid=" + str(uid) + ";"
+        main.dbinteract(query)
 
     # Convert to numpy structures and make inverse versions of tests if required.
     # Any test with true positive rate of zero is discarded.
@@ -182,7 +182,7 @@ def find_roc(table,
             if verbose: print '  ' + bestchoice + ' was selected'
             if fprs[besti] > 0:
                 if tprs[besti] / fprs[besti] < effectiveness_threshold:
-                    print '      WARNING - TPR / FPR is below the effectiveness threshold: ', tprs[besti] / fprs[besti]
+                    print 'WARNING - ' + bestchoice + ' TPR / FPR is below the effectiveness threshold: ', tprs[besti] / fprs[besti]
             cumulative = np.logical_or(cumulative, tests[besti])
             currenttpr, currentfpr, fnr, tnr = main.calcRates(cumulative, truth)
             testcomb.append(names[besti])

--- a/qctest_groups.csv
+++ b/qctest_groups.csv
@@ -49,8 +49,3 @@ Fuzzy logic,Optional,CoTeDe_Morello2014,
 XBT surface spikes,Optional,CSIRO_surface_spikes,Not a standard spike check; specific to XBTs
 Track check,Optional,EN_track_check,Check on position of successive profiles
 Maximum depth,Optional,ICDC_aqc_04_max_obs_depth,Defines maximum possible depth for instruments and flags data exceeding these
-Fuzzy logic,Optional,CoTeDe_fuzzy_logic,
-Fuzzy logic,Optional,CoTeDe_Morello2014,
-XBT surface spikes,Optional,CSIRO_surface_spikes,Not a standard spike check; specific to XBTs
-Track check,Optional,EN_track_check,Check on position of successive profiles
-Maximum depth,Optional,ICDC_aqc_04_max_obs_depth,Defines maximum possible depth for instruments and flags data exceeding these

--- a/qctest_groups.csv
+++ b/qctest_groups.csv
@@ -1,9 +1,9 @@
 Test group,Rule,QC test,Comment
-Sensible lat/lon,Pre-chosen,Argo_impossible_location_test,Non controversial sanity check on location
-Sensible date,Pre-chosen,Argo_impossible_date_test,Non controversial sanity check on date
-Near surface XBT data,Pre-chosen,CSIRO_depth,Standard reject of XBT data < 3.6 m
-Wire break,Pre-chosen,CSIRO_wire_break,Expert opinion is that this is highly reliable at detecting XBT wire breaks
-Depth above surface,Pre-chosen,ICDC_aqc_01_level_order,Flags depths less than zero (plus preprocessing for other ICDC checks)
+Sensible lat/lon,Remove profile,Argo_impossible_location_test,Non controversial sanity check on location
+Sensible date,Remove profile,Argo_impossible_date_test,Non controversial sanity check on date
+Near surface XBT data,Remove rejected levels,CSIRO_depth,Standard reject of XBT data < 3.6 m
+Wire break,Remove below reject,CSIRO_wire_break,Expert opinion is that this is highly reliable at detecting XBT wire breaks
+Depth above surface,Remove rejected levels,ICDC_aqc_01_level_order,Flags depths less than zero (plus preprocessing for other ICDC checks)
 Range,At least one from group,Argo_global_range_check,
 Range,At least one from group,Argo_regional_range_test,
 Range,At least one from group,CoTeDe_GTSPP_global_range,
@@ -11,7 +11,7 @@ Range,At least one from group,CoTeDe_GTSPP_profile_envelop,
 Range,At least one from group,EN_range_check,
 Range,At least one from group,ICDC_aqc_02_crude_range,
 Range,At least one from group,ICDC_aqc_06_n_temperature_extrema,
-Range,At-least one from group,WOD_range_check,
+Range,At least one from group,WOD_range_check,
 Gradient,At least one from group,Argo_gradient_test,
 Gradient,At least one from group,CoTeDe_gradient,
 Gradient,At least one from group,CoTeDe_GTSPP_gradient,
@@ -29,7 +29,7 @@ Spike or step,At least one from group,Argo_spike_test,
 Spike or step,At least one from group,CoTeDe_GTSPP_spike_check,
 Spike or step,At least one from group,CoTeDe_spike,
 Spike or step,At least one from group,EN_spike_and_step_check,
-Spike or step,At least one from group,EN_spike_and_step_suspect,
+Spike or step,Optional,EN_spike_and_step_suspect,
 Spike or step,At least one from group,ICDC_aqc_07_spike_check,
 Density,At least one from group,CoTeDe_Argo_density_inversion,
 Density,At least one from group,EN_stability_check,
@@ -44,6 +44,11 @@ Constant values,At least one from group,EN_constant_value_check,
 Constant values,At least one from group,ICDC_aqc_05_stuck_value,
 Anomaly detection,Optional,CoTeDe_anomaly_detection,Machine learning
 Digit roll over,Optional,CoTeDe_digit_roll_over,Argo digit rollover test
+Fuzzy logic,Optional,CoTeDe_fuzzy_logic,
+Fuzzy logic,Optional,CoTeDe_Morello2014,
+XBT surface spikes,Optional,CSIRO_surface_spikes,Not a standard spike check; specific to XBTs
+Track check,Optional,EN_track_check,Check on position of successive profiles
+Maximum depth,Optional,ICDC_aqc_04_max_obs_depth,Defines maximum possible depth for instruments and flags data exceeding these
 Fuzzy logic,Optional,CoTeDe_fuzzy_logic,
 Fuzzy logic,Optional,CoTeDe_Morello2014,
 XBT surface spikes,Optional,CSIRO_surface_spikes,Not a standard spike check; specific to XBTs

--- a/qctests/ICDC_aqc_07_spike_check.py
+++ b/qctests/ICDC_aqc_07_spike_check.py
@@ -26,15 +26,16 @@ def test(p, parameters):
     
     # The test is run on re-ordered data.
     nlevels, z, t = ICDC.reordered_data(p)
-    qc = np.zeros(nlevels, dtype=bool)
-    if nlevels < 3: return qc # Not enough levels to check.
+    qc = np.zeros(nlevels, dtype=bool) # Reordered data may be a subset of available levels.
+    defaultqc = np.zeros(p.n_levels(), dtype=bool) # Default QC flags for full set of levels.
+    if nlevels < 3: return defaultqc # Not enough levels to check.
 
     # Ignore any levels outside of limits.
     parminover = -2.3
     parmaxover = 33.0
     use = (t > parminover) & (t < parmaxover)
     nuse = np.count_nonzero(use)
-    if nuse < 3: return qc
+    if nuse < 3: return defaultqc
     zuse = z[use]
     tuse = t[use]
     origlevels = (np.arange(nlevels))[use]

--- a/util/dbutils.py
+++ b/util/dbutils.py
@@ -67,12 +67,12 @@ def check_for_fail(results):
 
     fails = []
     for result in results:
-        result = False
+        answer = False
         for qc in unpack_qc(result):
             if qc == True:
-                result = True
+                answer = True
                 break
-        fails.append(result)
+        fails.append(answer)
 
     return fails
 
@@ -130,8 +130,12 @@ def db_to_df(table,
         # Check if the action is relevant.
         if action == 'Optional' or action == 'At least one from group': continue
 
+        # Initialise variables.
+        nlevels   = -1
+        outcomes  = False
+        qcresults = []
         for testname in filter_on_tests[action]:
-            for i in range(0, len(df.index), -1):
+            for i in range(len(df.index) - 1, -1, -1):
                 if action == 'Remove above reject':
                     nlevels = get_reversed_n_levels_before_fail([df[testname][i]])[0]
                 elif action == 'Remove below reject':
@@ -143,9 +147,9 @@ def db_to_df(table,
                 else:
                     raise NameError('Unrecognised action: ' + action)
 
-                if (((action == 'Remove above reject' or action == 'Remove below reject') and nlevels[i] == 0) or
-                     (action == 'Remove profile' and outcomes[i] == True) or
-                     (action == 'Remove rejected levels' and np.count_nonzero(qcresults == False) == 0)):
+                if (((action == 'Remove above reject' or action == 'Remove below reject') and nlevels == 0) or
+                    (action == 'Remove profile' and outcomes == True) or
+                    (action == 'Remove rejected levels' and numpy.count_nonzero(qcresults == False) == 0)):
                     # Completely remove a profile if it has no valid levels or if it
                     # has a fail and the action is to remove.
                     df.drop(df.index[i])
@@ -156,9 +160,9 @@ def db_to_df(table,
                         qc = unpack_qc(df.iloc[i, j])
                         if len(qc) > 1:
                             if action == 'Remove above reject':
-                                qc = qc[nlevels[i]:]
+                                qc = qc[nlevels:]
                             elif action == 'Remove below reject':
-                                qc = qc[:nlevels[i]] 
+                                qc = qc[:nlevels] 
                             elif action == 'Remove rejected levels':
                                 qc = qc[qcresults == False]            
                             df.iat[i, j] = main.pack_array(qc)

--- a/util/dbutils.py
+++ b/util/dbutils.py
@@ -48,14 +48,49 @@ def get_n_levels_before_fail(results):
 
     return nlevels
 
+def get_reversed_n_levels_before_fail(results):
+
+    nlevels = []
+    for result in results:
+        n = 0
+        for qc in unpack_qc(result)[::-1]:
+            if qc == False:
+                n -= 1
+            else:
+                break
+        
+        nlevels.append(n)
+
+    return nlevels
+
+def check_for_fail(results):
+
+    fails = []
+    for result in results:
+        result = False
+        for qc in unpack_qc(result):
+            if qc == True:
+                result = True
+                break
+        fails.append(result)
+
+    return fails
+
+def unpack_qc_results(results):
+
+    return [unpack_qc(result) for result in results] 
+
 def db_to_df(table,
              filter_on_wire_break_test=False, 
+             filter_on_tests=[],
              n_to_extract=numpy.iinfo(numpy.int32).max):
 
     '''
     Reads the table from iquod.db into a pandas dataframe.
     If filter_on_wire_break_test is True, the results from that test are used to exclude
          levels below a wire break from the test results and the wire break test is not returned.
+    filter_on_tests is a generalised form of filter_on_wire_break and is used to exclude results; it takes a list of
+         [testname, action], where levels failing <testname> are excluded towards the surface (if action is 'up'), towards depth (if action is 'down') and the whole profile deleted (if action is 'remove').
     Set n_to_extract to limit the number of rows extracted to the specified number.
     '''
 
@@ -91,6 +126,46 @@ def db_to_df(table,
                     qc = qc[:nlevels[i]]
                 df.iat[i, j] = main.pack_array(qc)
 
+    for ftest in filter_on_tests:
+        testname = ftest[0]
+        action   = ftest[1]
+
+        for i in range(0, len(df.index), -1):
+
+            if action == 'removeabove':
+                nlevels = get_reversed_n_levels_before_fail([df[testname][i]])[0]
+            elif action == 'removebelow':
+                nlevels = get_n_levels_before_fail([df[testname][i]])[0]
+            elif action == 'removeprofile':
+                outcomes = check_for_fail([df[testname][i]])[0]
+            elif action == 'removelevels':
+                qcresults = unpack_qc_results([df[testname][i]])[0]
+            else:
+                raise NameError('Unrecognised action: ' + action)
+
+            if (((action == 'removeabove' or action == 'removebelow') and nlevels[i] == 0) or
+               (action == 'removeprofile' and outcomes[i] == True) or
+               (action == 'removelevels' and np.count_nonzero(qcresults == False) == 0)):
+                # Completely remove a profile if it has no valid levels or if it
+                # has a fail and the action is to remove.
+                df.drop(df.index[i])
+            elif (action != 'removeprofile'):
+                for j in range(1, len(df.columns)):
+                    # Retain only the levels that passed testname.
+                    # Some QC tests may return only one value so check for this.
+                    qc = unpack_qc(df.iloc[i, j])
+                    if len(qc) > 1:
+                        if action == 'removeabove':
+                            qc = qc[nlevels[i]:]
+                        elif action == 'removebelow':
+                            qc = qc[:nlevels[i]] 
+                        elif action == 'removelevels':
+                            qc = qc[qcresults == False]            
+                        df.iat[i, j] = main.pack_array(qc)
+
+        del df[testname] # No need to keep this any longer.
+
+    testNames = df.columns[2:].values.tolist()
     df[['Truth']] = df[['Truth']].apply(parse_truth)
     df[testNames] = df[testNames].apply(parse)
 


### PR DESCRIPTION
This pull request is an attempt to implement finding a best QC set by enforcing the use of at least one from each type of QC test that is designed to catch particular error modes (such as a spike). Updates are:

- Read QC group definition from a CSV file; this allows filtering the data using the results of particular tests.
- Five QC tests were 'pre-chosen': wire breaks test, checks that location and time data are plausible, check that depth is zero or greater, and reject of XBT levels < 3.6 m (which is a standard thing to do for XBTs).
- The best test from each QC group (defined as being the closest to 100% TPR and 0% FPR) is selected. 
- Other tests are then added using the existing method or trying to maximise the gradient of the ROC curve.
- An issue was identified with the ICDC spike check, where the test can return QC flags for fewer levels than it should. This has been fixed.