### PR TITLE
preliminary improvements to en-track

### DIFF
--- a/build-db.py
+++ b/build-db.py
@@ -27,7 +27,9 @@ if len(sys.argv) == 3:
                 time real,
                 lat real,
                 long real,
-                cruise text,
+                country text,
+                cruise integer,
+                ocruise text,
                 probe integer,
                 training integer,
                 """
@@ -132,8 +134,11 @@ if len(sys.argv) == 3:
         truth = encodeTruth(profile)
         p['truth'] = main.pack_array(truth)
 
-        # extract country code to prefix cruise
+        # extract country code
         country = profile.primary_header['Country code']
+
+        # originator cruise
+        orig_cruise = profile.originator_cruise()
 
         # keep tabs on how many good and how many bad profiles have been added to db
         # nowire == index of first wire break level
@@ -149,8 +154,8 @@ if len(sys.argv) == 3:
         else:
             good += 1
 
-        query = "INSERT INTO " + sys.argv[2] + " (raw, truth, uid, year, month, day, time, lat, long, cruise, probe) values (?,?,?,?,?,?,?,?,?,?,?);"
-        values = (p['raw'], p['truth'], p['uid'], p['year'], p['month'], p['day'], p['time'], p['latitude'], p['longitude'], country + str(p['cruise']), p['probe_type'])
+        query = "INSERT INTO " + sys.argv[2] + " (raw, truth, uid, year, month, day, time, lat, long, country, cruise, ocruise, probe) values (?,?,?,?,?,?,?,?,?,?,?,?,?);"
+        values = (p['raw'], p['truth'], p['uid'], p['year'], p['month'], p['day'], p['time'], p['latitude'], p['longitude'], country, p['cruise'], orig_cruise, p['probe_type'])
         main.dbinteract(query, values)
         if profile.is_last_profile_in_file(fid) == True:
             break

--- a/build-db.py
+++ b/build-db.py
@@ -27,7 +27,7 @@ if len(sys.argv) == 3:
                 time real,
                 lat real,
                 long real,
-                cruise integer,
+                cruise text,
                 probe integer,
                 training integer,
                 """
@@ -100,6 +100,7 @@ if len(sys.argv) == 3:
     uids = []
     good = 0
     bad = 0
+
     while True:
         # extract profile as wodpy object and raw text
         start = fid.tell()
@@ -131,6 +132,9 @@ if len(sys.argv) == 3:
         truth = encodeTruth(profile)
         p['truth'] = main.pack_array(truth)
 
+        # extract country code to prefix cruise
+        country = profile.primary_header['Country code']
+
         # keep tabs on how many good and how many bad profiles have been added to db
         # nowire == index of first wire break level
         wireqc = qctests.CSIRO_wire_break.test(profile, {})
@@ -146,7 +150,7 @@ if len(sys.argv) == 3:
             good += 1
 
         query = "INSERT INTO " + sys.argv[2] + " (raw, truth, uid, year, month, day, time, lat, long, cruise, probe) values (?,?,?,?,?,?,?,?,?,?,?);"
-        values = (p['raw'], p['truth'], p['uid'], p['year'], p['month'], p['day'], p['time'], p['latitude'], p['longitude'], p['cruise'], p['probe_type'])
+        values = (p['raw'], p['truth'], p['uid'], p['year'], p['month'], p['day'], p['time'], p['latitude'], p['longitude'], country + str(p['cruise']), p['probe_type'])
         main.dbinteract(query, values)
         if profile.is_last_profile_in_file(fid) == True:
             break


### PR DESCRIPTION
I've been fiddling with `EN_track` since Oostende to try and address issues discussed in #225 and #226. While this PR doesn't quite get us where I'd like to be, it makes some necessary improvements:

 - Per @BoyerWOD's comments, cruises are identified including the 2-character country code, and profiles reporting aircraft platforms are dropped. Note that profiles reporting country code 99 (unidentified / error) are not considered at this time.
 - Previous implementation of this test checked the suitability of the first profile passed to the test for assessment by EN_track, but didn't impose the same conditions on the collection of other profiles found to share a track with the first; this was an oversight, corrected here.
 - Speed thresholds are doubled, to 30 m/s for ships and 4 m/s for buoys. This was to accommodate instances of profiles getting flagged that just barely failed the test; see DE901006 for an example of a perfectly reasonable looking cruise that was just a little too fast.

These changes take us on our QuOTA sample from a TPR / FPR of 61.8% / 74.7% previously to 17.6% / 16.3%; most of the reduction in gross flags is currently due to not considering profiles with country code == 99. TPR > FPR is at least superficially auspicious, but it remains TBD how this affects downstream test combination algorithms, and if and how we can do even better.

More work forthcoming, but this seems like at least small progress to begin with.