### PR TITLE
AOML_constant check

### DIFF
--- a/qctests/AOML_constant.py
+++ b/qctests/AOML_constant.py
@@ -1,0 +1,20 @@
+# constant value test adpated from Patrick Halsall's 
+# ftp://ftp.aoml.noaa.gov/phod/pub/bringas/XBT/AQC/AOML_AQC_2018/codes/qc_checks/constant_checker.py
+
+import numpy
+
+def test(p, parameters):
+
+    qc = numpy.zeros(p.n_levels(), dtype=bool)
+    t = p.t()
+
+    # make sure there's more than one unmasked temperature
+    unmasked_t = [q for q in t if not numpy.ma.is_masked(q) ]
+    if len(unmasked_t) == 1:
+        return qc
+
+    unique_t = set(unmasked_t)
+    if len(unique_t) == 1:
+        return numpy.ones(p.n_levels(), dtype=bool)
+
+    return qc

--- a/tests/AOML_constant_check.py
+++ b/tests/AOML_constant_check.py
@@ -1,0 +1,30 @@
+import qctests.AOML_constant
+import util.testingProfile
+import numpy
+
+def test_AOML_constant():
+    '''
+    Test basic behavior of AOML_constant
+    '''
+
+    p = util.testingProfile.fakeProfile([0,0,0], [0, 1, 2]) 
+    qc = qctests.AOML_constant.test(p, None)
+    truth = numpy.ones(3, dtype=bool)
+    assert numpy.array_equal(qc, truth), 'failed to flag constant temperature'
+
+    t = numpy.ma.MaskedArray([1,2,1], [0,1,0])
+    p = util.testingProfile.fakeProfile(t, [0, 1, 2]) 
+    qc = qctests.AOML_constant.test(p, None)
+    truth = numpy.ones(3, dtype=bool)
+    assert numpy.array_equal(qc, truth), 'failed to ignore masked value correctly'
+
+    p = util.testingProfile.fakeProfile([0], [0]) 
+    qc = qctests.AOML_constant.test(p, None)
+    truth = numpy.zeros(1, dtype=bool)
+    assert numpy.array_equal(qc, truth), 'flagged single level profile'
+
+    t = numpy.ma.MaskedArray([1,1], [0,1])
+    p = util.testingProfile.fakeProfile(t, [0, 1]) 
+    qc = qctests.AOML_constant.test(p, None)
+    truth = numpy.zeros(2, dtype=bool)
+    assert numpy.array_equal(qc, truth), 'flagged profile with only a single unmasked level'


### PR DESCRIPTION
xbt perf check:

```
No parameters to load for AOML_constant
                       NAME OF TEST   FAILS     TPR     FPR     TNR     FNR
                              Truth   10172  100.0%    0.0%  100.0%    0.0%
                      AOML_constant     248    0.4%    0.4%   99.6%   99.6%
```