### PR TITLE
add flag to db for selecting good / bad profiles

### DIFF
--- a/build-db.py
+++ b/build-db.py
@@ -32,6 +32,7 @@ if len(sys.argv) == 3:
                 ocruise text,
                 probe integer,
                 training integer,
+                flagged integer,
                 """
     for i in range(len(testNames)):
         query += testNames[i].lower() + ' BLOB'
@@ -154,8 +155,8 @@ if len(sys.argv) == 3:
         else:
             good += 1
 
-        query = "INSERT INTO " + sys.argv[2] + " (raw, truth, uid, year, month, day, time, lat, long, country, cruise, ocruise, probe) values (?,?,?,?,?,?,?,?,?,?,?,?,?);"
-        values = (p['raw'], p['truth'], p['uid'], p['year'], p['month'], p['day'], p['time'], p['latitude'], p['longitude'], country, p['cruise'], orig_cruise, p['probe_type'])
+        query = "INSERT INTO " + sys.argv[2] + " (raw, truth, uid, year, month, day, time, lat, long, country, cruise, ocruise, probe, flagged) values (?,?,?,?,?,?,?,?,?,?,?,?,?,?);"
+        values = (p['raw'], p['truth'], p['uid'], p['year'], p['month'], p['day'], p['time'], p['latitude'], p['longitude'], country, p['cruise'], orig_cruise, p['probe_type'], int(flagged))
         main.dbinteract(query, values)
         if profile.is_last_profile_in_file(fid) == True:
             break

--- a/filter-db.py
+++ b/filter-db.py
@@ -1,0 +1,25 @@
+# usage: python filter-db.py <full table name> <filtered table name> <number of good / bad profiles to pick>
+
+import sys, sqlite3
+
+if len(sys.argv) == 4:
+
+    conn = sqlite3.connect('iquod.db', isolation_level=None)
+    cur = conn.cursor()
+
+    query = "DROP TABLE IF EXISTS " + sys.argv[2]
+    cur.execute(query)
+
+    n = sys.argv[3]
+    query = "CREATE TABLE " + sys.argv[2] + " AS SELECT * FROM " + sys.argv[1] + " WHERE flagged=0 ORDER BY RANDOM() LIMIT " + str(n)
+    cur.execute(query)
+    query = "INSERT INTO " + sys.argv[2] + " SELECT * FROM " + sys.argv[1] + " WHERE flagged=1 ORDER BY RANDOM() LIMIT " + str(n)
+    cur.execute(query)
+
+    query = "CREATE UNIQUE INDEX uid ON " + sys.argv[2] + "(uid);"
+    cur.execute(query)
+
+    conn.commit()
+else:
+
+    print "usage: python filter-db.py <full table name> <filtered table name> <number of good / bad profiles to pick>"


### PR DESCRIPTION
@s-good this is the filtering flag I mentioned via email earlier today, and what I used producing my results for Oostende; the db flag tracks whether a profile has originator flags at depths shallower than those flagged as a wire break.  `filter-db.py` creates a downsampled table with equal numbers of good and bad profiles, as a somewhat naive training sample construction.

Per your suggestion, we can make decisions about sampling later - but it'd be nice for the production run to have this flag present.