### PR TITLE
aoml spike needs at least 3 levels to make sense

### DIFF
--- a/qctests/AOML_spike.py
+++ b/qctests/AOML_spike.py
@@ -7,6 +7,9 @@ import numpy
 def test(p, parameters):
 
     qc = numpy.zeros(p.n_levels(), dtype=bool)
+    # this spike test only makes sense for 3 or more levels
+    if p.n_levels() < 3:
+        return qc
 
     t = p.t()
 


### PR DESCRIPTION
I get a lot of errors from AOML_spike, whenever it hits a surface measurement:

```
AOML_spike exception (<type 'exceptions.IndexError'>, IndexError('index 1 is out of bounds for axis 0 with size 1',), <traceback object at 0x7f709d3c0440>)
```

The current implementation assumes at least 3 levels in the profile; this PR demands as much or returns no flags.