### PR TITLE
Modifications for QuOTA production run

### DIFF
--- a/AutoQC.py
+++ b/AutoQC.py
@@ -83,14 +83,22 @@ if len(sys.argv)>2:
   uids = main.dbinteract(query)
   
   # launch async processes
+  if len(sys.argv) > 4:
+    batchnumber = int(sys.argv[3])
+    nperbatch   = int(sys.argv[4])
+    startindex  = batchnumber*nperbatch
+    endindex    = min((batchnumber+1)*nperbatch,len(uids))
+  else:
+    startindex  = 0
+    endindex    = len(uids)
   pool = Pool(processes=int(sys.argv[2]))
-  for i in range(len(uids)):
+  for i in range(startindex, endindex):
     pool.apply_async(process_row, (uids[i][0], logdir))
   pool.close()
   pool.join()
     
 else:
   print 'Please add command line arguments to name your output file and set parallelization:'
-  print 'python AutoQC <database results table> <number of processes>'
-  print 'will use <database results table> to log QC results in the database, and run the calculation parallelized over <number of processes>.'
+  print 'python AutoQC <database results table> <number of processes> <batch> <number of processes per batch> [<batchnumber> <number per batch>]'
+  print 'will use <database results table> to log QC results in the database, and run the calculation parallelized over <number of processes>. By default all profiles will be processed, but optionally the processing can be done in batches of size <number per batch>.'
 

--- a/build-db.py
+++ b/build-db.py
@@ -7,7 +7,8 @@ import util.dbutils as dbutils
 import numpy as np
 import qctests.CSIRO_wire_break
 
-if len(sys.argv) == 3:
+def builddb(check_originator_flag_type = True,
+            months_to_use = range(1, 13)):
 
     conn = sqlite3.connect('iquod.db', isolation_level=None)
     cur = conn.cursor()
@@ -63,7 +64,12 @@ if len(sys.argv) == 3:
             return False
 
         # no valid originator flag type
-        if int(p.originator_flag_type()) not in range(1,15):
+        if check_originator_flag_type:
+            if int(p.originator_flag_type()) not in range(1,15):
+                return False
+                
+        # check month
+        if p.month() not in months_to_use:
             return False
 
         temp = p.t()
@@ -164,9 +170,23 @@ if len(sys.argv) == 3:
     conn.commit()
     print 'number of clean profiles written:', good
     print 'number of flagged profiles written:', bad
+    print 'total number of profiles written:', good+bad
+
+if len(sys.argv) == 3:
+
+    builddb()
+    
+elif len(sys.argv) == 4:
+
+   if sys.argv[3] == 'quota':
+       builddb(check_originator_flag_type = False,
+               months_to_use = [1, 2, 3, 6])
+   else:
+       print 'Only configuration set up at the moment is quota but you selected ' + sys.argv[3]
+
 else:
 
-    print 'Usage: python build-db.py inputdatafile databasetable' 
+    print 'Usage: python build-db.py inputdatafile databasetable [configuration]' 
 
 
 


### PR DESCRIPTION
These two changes are:

1. Set up the build-db.py program to ignore originator_profile_type (as QuOTA does not have this set) and only read data for months 1, 2, 3 and 6 (the months fully manually quality controlled in QuOTA). This is selected by adding an optional configuration keyword to the end of the calling string.

2. A small modification to AutoQC.py to allow processing to be run in batches. This is helpful when there is a limit on how long a process is allowed to run as it makes it easy to break the processing into shorter batches.