### PR TITLE
Fix interpretation of True/False in command line

### DIFF
--- a/build-db.py
+++ b/build-db.py
@@ -178,13 +178,12 @@ if len(sys.argv) == 3:
     
 elif len(sys.argv) == 5:
 
-    months = sys.argv[4].split(',')
-    months = [int(x) for x in months]
-    builddb(ast.literal_eval(sys.argv[3]), months)  
+    builddb(ast.literal_eval(sys.argv[3]), ast.literal_eval(sys.argv[4]))  
 
 else:
 
-    print 'Usage: python build-db.py <inputdatafile> <databasetable> <demand originator flags> <list of months to include>' 
+    print 'Usage: python build-db.py <inputdatafile> <databasetable> <demand originator flags> <list of months to include (with no spaces or enclose in quotes)>' 
+    print 'Example: python build-db.py data.wod mytable False [1,2,3,10]'
 
 
 

--- a/build-db.py
+++ b/build-db.py
@@ -6,6 +6,7 @@ import util.main as main
 import util.dbutils as dbutils
 import numpy as np
 import qctests.CSIRO_wire_break
+import ast
 
 def assessProfile(p, check_originator_flag_type, months_to_use):
     'decide whether this profile is acceptable for QC or not; False = skip this profile'
@@ -179,7 +180,7 @@ elif len(sys.argv) == 5:
 
     months = sys.argv[4].split(',')
     months = [int(x) for x in months]
-    builddb(bool(sys.argv[3]), months)  
+    builddb(ast.literal_eval(sys.argv[3]), months)  
 
 else:
 


### PR DESCRIPTION
We recently changed build-db.py to allow setting a logical from the command line. The syntax used looked like it should work:

`bool(sys.argv[3])`

However, it turns out that anything except an empty string gets turned into True by this.

This is an option for an alternative:

`ast.literal_eval(sys.argv[3])`

It uses the ast built in Python module. It works, but I don't know if this is the best solution.