### PR TITLE
dont ask for more points than possible from kdtree

### DIFF
--- a/util/AOMLinterpolation.py
+++ b/util/AOMLinterpolation.py
@@ -97,7 +97,7 @@ def nearest_indices(y, x, latLonList, amountNearNeighbors):
   """
 
   tree = spatial.cKDTree(latLonList)
-  return tree.query([y,x], amountNearNeighbors)
+  return tree.query([y,x], min(amountNearNeighbors, len(latLonList)) )
 
 def temperature_interpolation_process(x, y, depth, depthColumns, llList,
                                       llTempList, zeroDepthMissing,

--- a/util/AOMLinterpolation.py
+++ b/util/AOMLinterpolation.py
@@ -161,11 +161,11 @@ def temperature_interpolation_process(x, y, depth, depthColumns, llList,
   nonanllTempList = [llTempList[indx] for indx in indicesNotNanList]
 
   # find the nearest point from the list above to the point of interest
-  numberOfNeighbors = 100
+  numberOfNeighbors = 1
   if nonanllList:
     distancesList, locationIndicesList = nearest_indices(y, x, nonanllList, numberOfNeighbors)
-    nearestRadDistance = distancesList[0]
-    nearestIndex = locationIndicesList[0]
+    nearestRadDistance = distancesList
+    nearestIndex = locationIndicesList
   else:
     return 99999.99
 


### PR DESCRIPTION
@s-good in our recent data run, I see a grand total of zero flags raised by AOML climatology. Digging in a bit, it seems that `nearest_indices` in `util/AOMLinterpolation.py` is using scipy's kdtree to ask for the 100 closest lat/long points from a pre-determined lattice closest to the profile's position, but there's no protection to make sure there are actually at least 100 points in the lattice to return. Ask for more neighbors than the lattice has, and kdtree just returns a bunch of infs (see example below). Also, why 100? It seems to only take the closest 1.

This PR forces a sensible return from kdtree, and only asks for the nearest neighbor.

Minimum example of bad behavior in kdtree:
```
import numpy as np
from scipy.spatial import cKDTree

ll = [[0,0],[0,0.5],[0,1],[0.5,0],[0.5,0.5],[0.5,1.0],[1.0,0],[1.0,0.5],[1.0,1.0]]
tree = cKDTree(ll)

print tree.query([0.5,0.5], 9)
print tree.query([0.5,0.5], 10)
```