### PR TITLE
test for xbt surface measurements

### DIFF
--- a/qctests/IQUOD_depth.py
+++ b/qctests/IQUOD_depth.py
@@ -1,0 +1,24 @@
+import numpy
+
+def test(p, parameters):
+    """
+    flag any single level surface measurement made by an XBT
+
+    Runs the quality control check on profile p and returns a numpy array
+    of quality control decisions with False where the data value has
+    passed the check and True where it failed.
+    """
+
+    # Get depth values (m) from the profile.
+    d = p.z()
+    # is this an xbt?
+    isXBT = p.probe_type() == 2
+
+    # initialize qc as a bunch of falses;
+    qc = numpy.zeros(p.n_levels(), dtype=bool)
+
+    # only interested in single level surface XBT measurements:
+    if p.n_levels() == 1 and d[0] < 1 and isXBT:
+        qc[0] = True
+
+    return qc


### PR DESCRIPTION
A new, very simple QC test that flags any single-level surface measurement claiming to be made by an XBT - essentially a more conservative `CSIRO_depth`, which has a huge false positive rate on our QuOTA sample.

Seems a bit silly at first, but this has a TPR / FPR of 0.8% / 0.0% in our QuOTA sample; what's more, a bunch of those bad profiles were sneaking through at least one final decision run into my false negatives.