### PR TITLE
make sure drop list isn't reset every action in db_to_df

### DIFF
--- a/util/dbutils.py
+++ b/util/dbutils.py
@@ -126,6 +126,7 @@ def db_to_df(table,
                     qc = qc[:nlevels[i]]
                 df.iat[i, j] = main.pack_array(qc)
 
+    todrop = set()
     for action in filter_on_tests:
         # Check if the action is relevant.
         if action == 'Optional' or action == 'At least one from group': continue
@@ -134,7 +135,6 @@ def db_to_df(table,
         nlevels   = -1
         outcomes  = False
         qcresults = []
-        todrop    = []
         for testname in filter_on_tests[action]:
             for i in range(0, len(df.index)):
                 if action == 'Remove above reject':
@@ -153,7 +153,7 @@ def db_to_df(table,
                     (action == 'Remove rejected levels' and numpy.count_nonzero(qcresults == False) == 0)):
                     # Completely remove a profile if it has no valid levels or if it
                     # has a fail and the action is to remove.
-                    todrop.append(i)
+                    todrop.add(i)
                 elif (action != 'Remove profile'):
                     for j in range(1, len(df.columns)):
                         # Retain only the levels that passed testname.
@@ -170,6 +170,7 @@ def db_to_df(table,
 
             del df[testname] # No need to keep this any longer.
 
+    todrop = list(todrop)
     if len(todrop) > 0:
         df.drop(todrop, inplace=True)
     df.reset_index(inplace=True, drop=True)


### PR DESCRIPTION
@s-good sorry I've been a bit quiet for a while, I was chasing around why I was getting a bunch of surface XBTs bloating my false negatives when they should have just been masked out - turns out that for multi-action filters (like the default one), the list of profiles dropped for having no valid levels after filtration was being reset every action - so only the last action actually causes profiles to get dropped in `db_to_df`.

Also, I've turned the drop list into a set, just to make sure we don't try and drop the same thing twice (especially dangerous when dropping by table row ID).