### PR TITLE
testing for bottom hits

### DIFF
--- a/qctests/IQUOD_bottom.py
+++ b/qctests/IQUOD_bottom.py
@@ -1,14 +1,24 @@
 import numpy
 import util.main as main
+from netCDF4 import Dataset
 
 def test(p, parameters):
+
+    # register bathymetry data in parameters object on first use
+    if 'bathymetry' not in parameters:
+        print 'extracting bathymetry'
+        nc = Dataset('data/ETOPO1_Bed_g_gmt4.grd')
+        parameters['bathymetry'] = {}
+        parameters['bathymetry']['longitude'] = nc.variables['x'][:]
+        parameters['bathymetry']['latitude'] = nc.variables['y'][:]
+        parameters['bathymetry']['depth'] = nc.variables['z'][:]
 
     d = p.z()
     lat = p.latitude()
     lon = p.longitude()
 
     # get ocean depth at this point
-    floor = -1.0*main.find_depth(lat, lon)
+    floor = -1.0*main.find_depth(lat, lon, parameters['bathymetry'])
 
     # initialize qc as a bunch of falses;
     qc = numpy.zeros(p.n_levels(), dtype=bool)

--- a/qctests/IQUOD_bottom.py
+++ b/qctests/IQUOD_bottom.py
@@ -1,24 +1,13 @@
 import numpy
 import util.main as main
-from netCDF4 import Dataset
 
 def test(p, parameters):
-
-    # register bathymetry data in parameters object on first use
-    if 'bathymetry' not in parameters:
-        print 'extracting bathymetry'
-        nc = Dataset('data/ETOPO1_Bed_g_gmt4.grd')
-        parameters['bathymetry'] = {}
-        parameters['bathymetry']['longitude'] = nc.variables['x'][:]
-        parameters['bathymetry']['latitude'] = nc.variables['y'][:]
-        parameters['bathymetry']['depth'] = nc.variables['z'][:]
 
     d = p.z()
     lat = p.latitude()
     lon = p.longitude()
 
-    # get ocean depth at this point
-    floor = -1.0*main.find_depth(lat, lon, parameters['bathymetry'])
+    floor = -1.0*main.find_depth(lat, lon)
 
     # initialize qc as a bunch of falses;
     qc = numpy.zeros(p.n_levels(), dtype=bool)

--- a/qctests/IQUOD_bottom.py
+++ b/qctests/IQUOD_bottom.py
@@ -1,0 +1,24 @@
+import numpy
+import googlemaps
+
+def test(p, parameters):
+
+    d = p.z()
+    lat = p.latitude()
+    lon = p.longitude()
+
+    # get ocean depth at this point
+    gmaps = googlemaps.Client(key='insert_api_key_here')
+    floor = -1.0*gmaps.elevation([(lat,lon)])[0]['elevation']
+
+    # initialize qc as a bunch of falses;
+    qc = numpy.zeros(p.n_levels(), dtype=bool)
+
+    # check for gaps in data
+    isDepth = (d.mask==False)
+
+    for i in range(p.n_levels()):
+        if isDepth[i]:
+            qc[i] = d[i] > floor
+
+    return qc

--- a/qctests/IQUOD_bottom.py
+++ b/qctests/IQUOD_bottom.py
@@ -1,5 +1,5 @@
 import numpy
-import googlemaps
+import util.main as main
 
 def test(p, parameters):
 
@@ -8,8 +8,7 @@ def test(p, parameters):
     lon = p.longitude()
 
     # get ocean depth at this point
-    gmaps = googlemaps.Client(key='insert_api_key_here')
-    floor = -1.0*gmaps.elevation([(lat,lon)])[0]['elevation']
+    floor = -1.0*main.find_depth(lat, lon)
 
     # initialize qc as a bunch of falses;
     qc = numpy.zeros(p.n_levels(), dtype=bool)

--- a/util/main.py
+++ b/util/main.py
@@ -325,16 +325,15 @@ def unpack_row(row):
 
     return tuple(res)
 
-def find_depth(latitude, longitude):
+def find_depth(latitude, longitude, bathymetry):
+    # find ocean depth at lat/long based on a dictionary 'bathymetry':
+    # bathymetry['longitude']: list of longitudes
+    # bathymetry['latitude']: list of latitudes
+    # bathymetry['deptth']: 2d array of depths as function of lat/long, with indices matching previos two lists
 
-    nc = Dataset('data/ETOPO1_Bed_g_gmt4.grd')
+    i_long = (np.abs(bathymetry['longitude'] - longitude)).argmin()
+    i_lat = (np.abs(bathymetry['latitude'] - latitude)).argmin()
 
-    long = nc.variables['x'][:]
-    lat = nc.variables['y'][:]
-    z = nc.variables['z'][:]
+    return bathymetry['depth'][i_lat, i_long]
 
-    i_long = (np.abs(long - longitude)).argmin()
-    i_lat = (np.abs(lat - latitude)).argmin()
-
-    return z[i_lat, i_long]
 

--- a/util/main.py
+++ b/util/main.py
@@ -7,6 +7,7 @@ from netCDF4 import Dataset
 import testingProfile
 from numbers import Number
 import tempfile
+import oceansdb
 
 def importQC(dir):
   '''
@@ -325,15 +326,9 @@ def unpack_row(row):
 
     return tuple(res)
 
-def find_depth(latitude, longitude, bathymetry):
-    # find ocean depth at lat/long based on a dictionary 'bathymetry':
-    # bathymetry['longitude']: list of longitudes
-    # bathymetry['latitude']: list of latitudes
-    # bathymetry['deptth']: 2d array of depths as function of lat/long, with indices matching previos two lists
+def find_depth(latitude, longitude):
 
-    i_long = (np.abs(bathymetry['longitude'] - longitude)).argmin()
-    i_lat = (np.abs(bathymetry['latitude'] - latitude)).argmin()
-
-    return bathymetry['depth'][i_lat, i_long]
+    db = oceansdb.ETOPO()
+    return db.extract(lat=latitude, lon=longitude)['elevation'][0]
 
 

--- a/util/main.py
+++ b/util/main.py
@@ -325,4 +325,16 @@ def unpack_row(row):
 
     return tuple(res)
 
+def find_depth(latitude, longitude):
+
+    nc = Dataset('data/ETOPO1_Bed_g_gmt4.grd')
+
+    long = nc.variables['x'][:]
+    lat = nc.variables['y'][:]
+    z = nc.variables['z'][:]
+
+    i_long = (np.abs(long - longitude)).argmin()
+    i_lat = (np.abs(lat - latitude)).argmin()
+
+    return z[i_lat, i_long]
 


### PR DESCRIPTION
~work in progress - not ready for merge~

Here's a sketch of a QC test that flags any level deeper than the ocean floor at the reported lat/long. Of the roughly 300 bad quota profiles we are currently failing to flag in our test sample (ie false negatives), about 50 are flagged by this test. This will likely be a part of the 'pre-cleaning' step where we discount obviously bad levels, like what we currently do for wire breaks.

While very successful at eliminating a large class of our remaining false negatives, this implementation relies on the google maps API to determine the depth of the sea floor, which is cost prohibitive ($5 USD / 1000 requests); a mergable implementation needs to be able to make this determination for free. @BoyerWOD, I see that NOAA provides bathymetry data at ex https://maps.ngdc.noaa.gov/viewers/bathymetry/; is there a machine-readable API version of this data?