### PR TITLE
patch environment for new icdc climatology

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_install:
 - docker image pull iquod/autoqc:ubuntu-16.04
 
 script:
-- docker container run -v $PWD:/AutoQC_latest iquod/autoqc:ubuntu-16.04 bash -c "cp /AutoQC/data/* /AutoQC_latest/data/.; cd /AutoQC_latest; /usr/local/bin/nosetests tests/*.py"
+- docker container run -v $PWD:/AutoQC_latest iquod/autoqc:ubuntu-16.04-patch-190606 bash -c "cp /AutoQC/data/* /AutoQC_latest/data/.; cd /AutoQC_latest; /usr/local/bin/nosetests tests/*.py"


### PR DESCRIPTION
Unfortunately I was not successful in rebuilding our environment from scratch from `install.sh` and our Dockerfile; luckily we have that environment captured for posterity as `iquod/autoqc:ubuntu-16.04`.

From that image, we can build patch environments that add on things like the climatology file ICDC_10 needs in order for #247 to pass. We should and will document that patch lineage in the Docker repo that holds those images.