### PR TITLE
use flags rather than positional arguments for all key scripts

### DIFF
--- a/AutoQC.py
+++ b/AutoQC.py
@@ -24,7 +24,7 @@ def process_row(uid, logdir, table='iquod', targetdb='iquod.db'):
   sys.stderr = open(logdir + "/" + str(uid) + ".stderr", "w")
 
   # extract profile
-  profile = main.get_profile_from_db(uid)
+  profile = main.get_profile_from_db(uid, table)
 
   # mask out error codes in temperature data
   main.catchFlags(profile)

--- a/AutoQC.py
+++ b/AutoQC.py
@@ -16,7 +16,7 @@ def run(test, profiles, parameters):
 
   return verbose
 
-def process_row(uid, logdir, table='iquod'):
+def process_row(uid, logdir, table='iquod', targetdb):
   '''run all tests on the indicated database row'''
 
   # reroute stdout, stderr to separate files for each profile to preserve logs
@@ -39,7 +39,7 @@ def process_row(uid, logdir, table='iquod'):
 
     try:
       query = "UPDATE " + table + " SET " + test + "=? WHERE uid=" + str(profile.uid()) + ";"
-      main.dbinteract(query, [main.pack_array(result)])
+      main.dbinteract(query, [main.pack_array(result)], targetdb)
     except:
       print('db exception', sys.exc_info())
 
@@ -50,6 +50,7 @@ def process_row(uid, logdir, table='iquod'):
 
 # parse options
 options, remainder = getopt.getopt(sys.argv[1:], 't:d:b:n:h')
+cores=1
 targetdb = 'iquod.db'
 dbtable = 'iquod'
 batchnumber = None
@@ -103,7 +104,7 @@ for test in testNames:
 
 # connect to database & fetch list of all uids
 query = 'SELECT uid FROM ' + dbtable + ' ORDER BY uid;'
-uids = main.dbinteract(query)
+uids = main.dbinteract(query, targetdb=targetdb)
 
 # launch async processes
 if batchnumber is not None and nperbatch is not None:
@@ -116,7 +117,7 @@ else:
   endindex    = len(uids)
 pool = Pool(processes=int(cores))
 for i in range(startindex, endindex):
-  pool.apply_async(process_row, (uids[i][0], logdir, dbtable))
+  pool.apply_async(process_row, (uids[i][0], logdir, dbtable, targetdb))
 pool.close()
 pool.join()
 

--- a/AutoQC.py
+++ b/AutoQC.py
@@ -39,7 +39,7 @@ def process_row(uid, logdir, table='iquod', targetdb='iquod.db'):
 
     try:
       query = "UPDATE " + table + " SET " + test + "=? WHERE uid=" + str(profile.uid()) + ";"
-      main.dbinteract(query, [main.pack_array(result)], targetdb)
+      main.dbinteract(query, [main.pack_array(result)], targetdb=targetdb)
     except:
       print('db exception', sys.exc_info())
 

--- a/AutoQC.py
+++ b/AutoQC.py
@@ -16,7 +16,7 @@ def run(test, profiles, parameters):
 
   return verbose
 
-def process_row(uid, logdir, table='iquod', targetdb):
+def process_row(uid, logdir, table='iquod', targetdb='iquod.db'):
   '''run all tests on the indicated database row'''
 
   # reroute stdout, stderr to separate files for each profile to preserve logs

--- a/AutoQC.py
+++ b/AutoQC.py
@@ -49,10 +49,11 @@ def process_row(uid, logdir, table='iquod', targetdb='iquod.db'):
 ########################################
 
 # parse options
-options, remainder = getopt.getopt(sys.argv[1:], 't:d:b:n:h')
+options, remainder = getopt.getopt(sys.argv[1:], 't:d:b:n:p:l:h')
 cores=1
 targetdb = 'iquod.db'
 dbtable = 'iquod'
+logdir = '/AutoQClogs'
 batchnumber = None
 nperbatch = None
 for opt, arg in options:
@@ -60,6 +61,8 @@ for opt, arg in options:
         batchnumber = ast.literal_eval(arg)
     if opt == '-d':
         dbtable = arg
+    if opt == '-l':
+        logdir = arg
     if opt == '-n':
         cores = ast.literal_eval(arg)
     if opt == '-p':
@@ -70,6 +73,7 @@ for opt, arg in options:
         print('usage:')
         print('-b <batch number to process>')
         print('-d <db table name to create and write to>')
+        print('-l <directory to write logfiles to>')
         print('-n <number of cores to use>')
         print('-p <how many profiles to process per batch>')
         print('-t <name of db file>')
@@ -85,7 +89,7 @@ for testName in testNames:
   print('  {}'.format(testName))
 
 # set up a directory for logging
-logdir = "autoqc-logs-" + str(calendar.timegm(time.gmtime()))
+logdir = logdir + "/autoqc-logs-" + str(calendar.timegm(time.gmtime()))
 os.makedirs(logdir)
 
 # Parallel processing.

--- a/AutoQC.py
+++ b/AutoQC.py
@@ -1,5 +1,5 @@
 from wodpy import wod
-import pickle, sys, os, calendar, time
+import pickle, sys, os, calendar, time, ast
 import numpy as np
 import util.main as main
 from multiprocessing import Pool
@@ -16,7 +16,7 @@ def run(test, profiles, parameters):
 
   return verbose
 
-def process_row(uid, logdir):
+def process_row(uid, logdir, table='iquod'):
   '''run all tests on the indicated database row'''
 
   # reroute stdout, stderr to separate files for each profile to preserve logs
@@ -38,7 +38,7 @@ def process_row(uid, logdir):
       result = np.zeros(1, dtype=bool)
 
     try:
-      query = "UPDATE " + sys.argv[1] + " SET " + test + "=? WHERE uid=" + str(profile.uid()) + ";"
+      query = "UPDATE " + table + " SET " + test + "=? WHERE uid=" + str(profile.uid()) + ";"
       main.dbinteract(query, [main.pack_array(result)])
     except:
       print('db exception', sys.exc_info())
@@ -48,56 +48,76 @@ def process_row(uid, logdir):
 # main
 ########################################
 
-if len(sys.argv)>2:
+# parse options
+options, remainder = getopt.getopt(sys.argv[1:], 't:d:b:n:h')
+targetdb = 'iquod.db'
+dbtable = 'iquod'
+batchnumber = None
+nperbatch = None
+for opt, arg in options:
+    if opt == '-b':
+        batchnumber = ast.literal_eval(arg)
+    if opt == '-d':
+        dbtable = arg
+    if opt == '-n':
+        cores = ast.literal_eval(arg)
+    if opt == '-p':
+        nperbatch = ast.literal_eval(arg)
+    if opt == '-t':
+        targetdb = arg
+    if opt == '-h':
+        print('usage:')
+        print('-b <batch number to process>')
+        print('-d <db table name to create and write to>')
+        print('-n <number of cores to use>')
+        print('-p <how many profiles to process per batch>')
+        print('-t <name of db file>')
+        print('-h print this help message and quit')
 
-  # Identify and import tests
-  testNames = main.importQC('qctests')
-  testNames.sort()
-  print('{} quality control checks have been found'.format(len(testNames)))
-  testNames = main.checkQCTestRequirements(testNames)
-  print('{} quality control checks are able to be run:'.format(len(testNames)))
-  for testName in testNames:
-    print('  {}'.format(testName))
+# Identify and import tests
+testNames = main.importQC('qctests')
+testNames.sort()
+print('{} quality control checks have been found'.format(len(testNames)))
+testNames = main.checkQCTestRequirements(testNames)
+print('{} quality control checks are able to be run:'.format(len(testNames)))
+for testName in testNames:
+  print('  {}'.format(testName))
 
-  # set up a directory for logging
-  logdir = "autoqc-logs-" + str(calendar.timegm(time.gmtime()))
-  os.makedirs(logdir)
+# set up a directory for logging
+logdir = "autoqc-logs-" + str(calendar.timegm(time.gmtime()))
+os.makedirs(logdir)
 
-  # Parallel processing.
-  print('\nPlease wait while QC is performed\n')
+# Parallel processing.
+print('\nPlease wait while QC is performed\n')
 
-  # set up global parmaeter store
-  parameterStore = {
-    "table": sys.argv[1]
-  }
-  for test in testNames:
-    exec('from qctests import ' + test)
-    try:
-      exec(test + '.loadParameters(parameterStore)')
-    except:
-      print('No parameters to load for', test)
+# set up global parmaeter store
+parameterStore = {
+  "table": dbtable
+}
+for test in testNames:
+  exec('from qctests import ' + test)
+  try:
+    exec(test + '.loadParameters(parameterStore)')
+  except:
+    print('No parameters to load for', test)
 
-  # connect to database & fetch list of all uids
-  query = 'SELECT uid FROM ' + sys.argv[1] + ' ORDER BY uid;'
-  uids = main.dbinteract(query)
+# connect to database & fetch list of all uids
+query = 'SELECT uid FROM ' + dbtable + ' ORDER BY uid;'
+uids = main.dbinteract(query)
 
-  # launch async processes
-  if len(sys.argv) > 4:
-    batchnumber = int(sys.argv[3])
-    nperbatch   = int(sys.argv[4])
-    startindex  = batchnumber*nperbatch
-    endindex    = min((batchnumber+1)*nperbatch,len(uids))
-  else:
-    startindex  = 0
-    endindex    = len(uids)
-  pool = Pool(processes=int(sys.argv[2]))
-  for i in range(startindex, endindex):
-    pool.apply_async(process_row, (uids[i][0], logdir))
-  pool.close()
-  pool.join()
-
+# launch async processes
+if batchnumber is not None and nperbatch is not None:
+  batchnumber = int(batchnumber)
+  nperbatch   = int(nperbatch)
+  startindex  = batchnumber*nperbatch
+  endindex    = min((batchnumber+1)*nperbatch,len(uids))
 else:
-  print('Please add command line arguments to name your output file and set parallelization:')
-  print('python AutoQC <database results table> <number of processes> <batch> <number of processes per batch> [<batchnumber> <number per batch>]')
-  print('will use <database results table> to log QC results in the database, and run the calculation parallelized over <number of processes>. By default all profiles will be processed, but optionally the processing can be done in batches of size <number per batch>.')
+  startindex  = 0
+  endindex    = len(uids)
+pool = Pool(processes=int(cores))
+for i in range(startindex, endindex):
+  pool.apply_async(process_row, (uids[i][0], logdir, dbtable))
+pool.close()
+pool.join()
+
 

--- a/AutoQC.py
+++ b/AutoQC.py
@@ -24,7 +24,7 @@ def process_row(uid, logdir, table='iquod', targetdb='iquod.db'):
   sys.stderr = open(logdir + "/" + str(uid) + ".stderr", "w")
 
   # extract profile
-  profile = main.get_profile_from_db(uid, table)
+  profile = main.get_profile_from_db(uid, table, targetdb)
 
   # mask out error codes in temperature data
   main.catchFlags(profile)
@@ -93,7 +93,8 @@ print('\nPlease wait while QC is performed\n')
 
 # set up global parmaeter store
 parameterStore = {
-  "table": dbtable
+  "table": dbtable,
+  "db": targetdb
 }
 for test in testNames:
   exec('from qctests import ' + test)

--- a/AutoQC.py
+++ b/AutoQC.py
@@ -1,5 +1,5 @@
 from wodpy import wod
-import pickle, sys, os, calendar, time, ast
+import pickle, sys, os, calendar, time, ast, getopt
 import numpy as np
 import util.main as main
 from multiprocessing import Pool

--- a/AutoQC.py
+++ b/AutoQC.py
@@ -60,7 +60,7 @@ for opt, arg in options:
     if opt == '-b':
         batchnumber = ast.literal_eval(arg)
     if opt == '-d':
-        dbtable = arg
+        dbtable = str(arg)
     if opt == '-l':
         logdir = arg
     if opt == '-n':

--- a/analyse-results.py
+++ b/analyse-results.py
@@ -203,8 +203,8 @@ def find_roc(table,
                     else:
                         if verbose: print('    ' + testname + ' not found and so was skipped')
             if bestchoice == '':
-                print('WARNING no suitable tests in group ' + key + ', skipping')
-                del groupdefinition['At least one from group'][bestgroup]
+                print('WARNING no suitable tests in group "' + key + '", skipping')
+                del groupdefinition['At least one from group'][key]
             else:
                 if verbose: print('  ' + bestchoice + ' was selected from group ' + bestgroup)
                 if fprs[besti] > 0:

--- a/analyse-results.py
+++ b/analyse-results.py
@@ -202,24 +202,27 @@ def find_roc(table,
                                     bestgroup  = key
                     else:
                         if verbose: print('    ' + testname + ' not found and so was skipped')
-            #assert bestchoice != '', '    Error, did not make a choice in group ' + key
-            if verbose: print('  ' + bestchoice + ' was selected from group ' + bestgroup)
-            if fprs[besti] > 0:
-                if tprs[besti] / fprs[besti] < effectiveness_ratio:
-                    print('WARNING - ' + bestchoice + ' TPR / FPR is below the effectiveness ratio limit: ', tprs[besti] / fprs[besti], effectiveness_ratio)
-            cumulative = np.logical_or(cumulative, tests[besti])
-            currenttpr, currentfpr, fnr, tnr = main.calcRates(cumulative, truth)
-            testcomb.append(names[besti])
-            r_fprs.append(currentfpr)
-            r_tprs.append(currenttpr)
-            groupsel.append(True)
-            # Once a test has been added, it can be deleted so that it is not considered again.
-            del names[besti]
-            del tests[besti]
-            del fprs[besti]
-            del tprs[besti]
-            del groupdefinition['At least one from group'][bestgroup]
-            print('ROC point from enforced group: ', currenttpr, currentfpr, testcomb[-1], bestgroup)
+            if bestchoice == '':
+                print('WARNING no suitable tests in group ' + key + ', skipping')
+                del groupdefinition['At least one from group'][bestgroup]
+            else:
+                if verbose: print('  ' + bestchoice + ' was selected from group ' + bestgroup)
+                if fprs[besti] > 0:
+                    if tprs[besti] / fprs[besti] < effectiveness_ratio:
+                        print('WARNING - ' + bestchoice + ' TPR / FPR is below the effectiveness ratio limit: ', tprs[besti] / fprs[besti], effectiveness_ratio)
+                cumulative = np.logical_or(cumulative, tests[besti])
+                currenttpr, currentfpr, fnr, tnr = main.calcRates(cumulative, truth)
+                testcomb.append(names[besti])
+                r_fprs.append(currentfpr)
+                r_tprs.append(currenttpr)
+                groupsel.append(True)
+                # Once a test has been added, it can be deleted so that it is not considered again.
+                del names[besti]
+                del tests[besti]
+                del fprs[besti]
+                del tprs[besti]
+                del groupdefinition['At least one from group'][bestgroup]
+                print('ROC point from enforced group: ', currenttpr, currentfpr, testcomb[-1], bestgroup)
 
     # Make combinations of the single checks and store.
     assert n_combination_iterations <= 2, 'Setting n_combination_iterations > 2 results in a very large number of combinations'

--- a/analyse-results.py
+++ b/analyse-results.py
@@ -129,11 +129,11 @@ def find_roc(table,
         print('Number of quality checks to process is: ', len(testNames))
 
     # mark chosen profiles as part of the training set 
-    all_uids = main.dbinteract('SELECT uid from ' + sys.argv[1] + ';', targetdb=targetdb)
+    all_uids = main.dbinteract('SELECT uid from ' + table + ';', targetdb=targetdb)
     for uid in all_uids:
         uid = uid[0]
         is_training = int(uid in df['uid'].astype(int).as_matrix())
-        query = "UPDATE " + sys.argv[1] + " SET training=" + str(is_training) + " WHERE uid=" + str(uid) + ";"
+        query = "UPDATE " + table + " SET training=" + str(is_training) + " WHERE uid=" + str(uid) + ";"
         main.dbinteract(query, targetdb=targetdb)
 
     # Convert to numpy structures and make inverse versions of tests if required.

--- a/analyse-results.py
+++ b/analyse-results.py
@@ -301,11 +301,11 @@ def find_roc(table,
         plt.ylim(0, 100)
         plt.xlabel('False positive rate (%)')
         plt.ylabel('True positive rate (%)')
-        plt.savefig('roc.png')
+        plt.savefig(plot_roc)
         plt.close()
 
     if write_roc:
-        f = open('roc.json', 'w')
+        f = open(write_roc, 'w')
         r = {}
         r['tpr'] = r_tprs
         r['fpr'] = r_fprs
@@ -317,9 +317,11 @@ def find_roc(table,
 if __name__ == '__main__':
 
     # parse options
-    options, remainder = getopt.getopt(sys.argv[1:], 't:d:n:c:h')
+    options, remainder = getopt.getopt(sys.argv[1:], 't:d:n:c:o:p:h')
     targetdb = 'iquod.db'
     dbtable = 'iquod'
+    outfile = False
+    plotfile = False
     samplesize = None
     costratio = [10.0, 10.0]
     for opt, arg in options:
@@ -331,17 +333,23 @@ if __name__ == '__main__':
             samplesize = int(arg)
         if opt == '-c':
             costratio = ast.literal_eval(arg)
+        if opt == '-o':
+            outfile = arg
+        if opt == '-p':
+            plotfile = arg
         if opt == '-h':
             print('usage:')
             print('-d <db table name to read from>')
             print('-t <name of db file>')
             print('-n <number of profiles to consider>')
             print('-c <cost ratio array>')
+            print('-o <filename to write json results out to>')
+            print('-p <filename to write roc plot out to>')
             print('-h print this help message and quit')
     if samplesize is None:
         print('please provide a sample size to consider with the -n flag')
         print('-h to print usage')
 
-    find_roc(table=dbtable, targetdb=targetdb, n_profiles_to_analyse=samplesize, costratio=costratio)
+    find_roc(table=dbtable, targetdb=targetdb, n_profiles_to_analyse=samplesize, costratio=costratio, plot_roc=plotfile, write_roc=outfile)
 
 

--- a/build-db.py
+++ b/build-db.py
@@ -187,8 +187,8 @@ elif len(sys.argv) == 5:
 
 else:
 
-    print('Usage: python build-db.py <inputdatafile> <databasetable>', or)
-    print('Usage: python build-db.py <inputdatafile> <databasetable> <output filename>', or)
+    print('Usage: python build-db.py <inputdatafile> <databasetable>, or')
+    print('Usage: python build-db.py <inputdatafile> <databasetable> <output filename>, or')
     print('Usage: python build-db.py <inputdatafile> <databasetable> <demand originator flags> <list of months to include (with no spaces or enclose in quotes)>')
 
 

--- a/build-db.py
+++ b/build-db.py
@@ -164,7 +164,7 @@ def builddb(infile, check_originator_flag_type = True,
 
         query = "INSERT INTO " + dbtable + " (raw, truth, uid, year, month, day, time, lat, long, country, cruise, ocruise, probe, flagged) values (?,?,?,?,?,?,?,?,?,?,?,?,?,?);"
         values = (p['raw'], p['truth'], p['uid'], p['year'], p['month'], p['day'], p['time'], p['latitude'], p['longitude'], country, p['cruise'], orig_cruise, p['probe_type'], int(flagged))
-        main.dbinteract(query, values, inputdb=outfile)
+        main.dbinteract(query, values, targetdb=outfile)
         if profile.is_last_profile_in_file(fid) == True:
             break
 

--- a/build-db.py
+++ b/build-db.py
@@ -1,7 +1,7 @@
-# usage: python build-db.py <wod ascii file name> <table name to append to>
+# usage help: python build-db.py -h
 
 from wodpy import wod
-import sys, sqlite3
+import sys, sqlite3, getopt
 import util.main as main
 import util.dbutils as dbutils
 import numpy as np
@@ -68,8 +68,8 @@ def encodeTruth(p):
             truth[i] = 99
     return truth
 
-def builddb(check_originator_flag_type = True,
-            months_to_use = range(1, 13), outfile='iquod.db'):
+def builddb(infile, check_originator_flag_type = True,
+            months_to_use = range(1, 13), outfile='iquod.db', dbtable='iquod'):
 
     conn = sqlite3.connect(outfile, isolation_level=None)
     cur = conn.cursor()
@@ -79,7 +79,7 @@ def builddb(check_originator_flag_type = True,
     testNames.sort()
 
     # set up our table
-    query = "CREATE TABLE IF NOT EXISTS " + sys.argv[2] + """(
+    query = "CREATE TABLE IF NOT EXISTS " + dbtable + """(
                 raw text,
                 truth BLOB,
                 uid integer PRIMARY KEY,
@@ -106,7 +106,7 @@ def builddb(check_originator_flag_type = True,
     cur.execute(query)
 
     # populate table from wod-ascii data
-    fid = open(sys.argv[1])
+    fid = open(infile)
     uids = []
     good = 0
     bad = 0
@@ -162,7 +162,7 @@ def builddb(check_originator_flag_type = True,
         else:
             good += 1
 
-        query = "INSERT INTO " + sys.argv[2] + " (raw, truth, uid, year, month, day, time, lat, long, country, cruise, ocruise, probe, flagged) values (?,?,?,?,?,?,?,?,?,?,?,?,?,?);"
+        query = "INSERT INTO " + dbtable + " (raw, truth, uid, year, month, day, time, lat, long, country, cruise, ocruise, probe, flagged) values (?,?,?,?,?,?,?,?,?,?,?,?,?,?);"
         values = (p['raw'], p['truth'], p['uid'], p['year'], p['month'], p['day'], p['time'], p['latitude'], p['longitude'], country, p['cruise'], orig_cruise, p['probe_type'], int(flagged))
         main.dbinteract(query, values, inputdb=outfile)
         if profile.is_last_profile_in_file(fid) == True:
@@ -173,23 +173,34 @@ def builddb(check_originator_flag_type = True,
     print('number of flagged profiles written:', bad)
     print('total number of profiles written:', good+bad)
 
-if len(sys.argv) == 3:
+# parse options
+options, remainder = getopt.getopt(sys.argv[1:], 'o:i:d:fm:h')
+inputdata = None
+dbtable = 'iquod'
+outfile = 'iquod.db'
+origflags = True
+months = range(1, 13)
+for opt, arg in options:
+    if opt == '-o':
+        outfile = arg
+    if opt == '-i':
+        inputdata = arg
+    if opt == '-d':
+        dbtable = arg
+    if opt == '-f':
+        origflags = False
+    if opt == '-m':
+        months = ast.literal_eval(arg)
+    if opt == '-h':
+        print('usage:')
+        print('-d <db table name to create and write to>')
+        print('-f dont check originator flags')
+        print('-h print this help message and quit')
+        print('-i <filename of raw WOD ascii data> (mandatory)')
+        print('-o <output file name>')
+        print('-m <list of months to include>')
+if inputdata is None:
+    print('Must provide raw ascii input data file with the flag `-i`')
 
-    builddb()
-
-elif len(sys.argv) == 4:
-
-    builddb(outfile=sys.argv[3])
-
-elif len(sys.argv) == 5:
-
-    builddb(ast.literal_eval(sys.argv[3]), ast.literal_eval(sys.argv[4]))  
-
-else:
-
-    print('Usage: python build-db.py <inputdatafile> <databasetable>, or')
-    print('Usage: python build-db.py <inputdatafile> <databasetable> <output filename>, or')
-    print('Usage: python build-db.py <inputdatafile> <databasetable> <demand originator flags> <list of months to include (with no spaces or enclose in quotes)>')
-
-
+builddb(inputdata, check_originator_flag_type = origflags, months_to_use = months, outfile = outfile, dbtable = dbtable)
 

--- a/build-db.py
+++ b/build-db.py
@@ -164,7 +164,7 @@ def builddb(check_originator_flag_type = True,
 
         query = "INSERT INTO " + sys.argv[2] + " (raw, truth, uid, year, month, day, time, lat, long, country, cruise, ocruise, probe, flagged) values (?,?,?,?,?,?,?,?,?,?,?,?,?,?);"
         values = (p['raw'], p['truth'], p['uid'], p['year'], p['month'], p['day'], p['time'], p['latitude'], p['longitude'], country, p['cruise'], orig_cruise, p['probe_type'], int(flagged))
-        main.dbinteract(query, values)
+        main.dbinteract(query, values, inputdb=outfile)
         if profile.is_last_profile_in_file(fid) == True:
             break
 

--- a/build-db.py
+++ b/build-db.py
@@ -69,9 +69,9 @@ def encodeTruth(p):
     return truth
 
 def builddb(check_originator_flag_type = True,
-            months_to_use = range(1, 13)):
+            months_to_use = range(1, 13), outfile='iquod.db'):
 
-    conn = sqlite3.connect('iquod.db', isolation_level=None)
+    conn = sqlite3.connect(outfile, isolation_level=None)
     cur = conn.cursor()
 
     # Identify tests
@@ -177,14 +177,19 @@ if len(sys.argv) == 3:
 
     builddb()
 
+elif len(sys.argv) == 4:
+
+    builddb(outfile=sys.argv[3])
+
 elif len(sys.argv) == 5:
 
     builddb(ast.literal_eval(sys.argv[3]), ast.literal_eval(sys.argv[4]))  
 
 else:
 
+    print('Usage: python build-db.py <inputdatafile> <databasetable>', or)
+    print('Usage: python build-db.py <inputdatafile> <databasetable> <output filename>', or)
     print('Usage: python build-db.py <inputdatafile> <databasetable> <demand originator flags> <list of months to include (with no spaces or enclose in quotes)>')
-    print('Example: python build-db.py data.wod mytable False [1,2,3,10]')
 
 
 

--- a/catchall.py
+++ b/catchall.py
@@ -79,7 +79,7 @@ bad = df.loc[df['Truth']]
 bad.reset_index(inplace=True, drop=True)
 
 # mark chosen profiles as part of the training set
-all_uids = main.dbinteract('SELECT uid from ' + dbtable + ';')
+all_uids = main.dbinteract('SELECT uid from ' + dbtable + ';', targetdb=targetdb)
 for uid in all_uids:
     uid = uid[0]
     is_training = int(uid in df['uid'].astype(int).as_matrix())

--- a/catchall.py
+++ b/catchall.py
@@ -84,7 +84,7 @@ for uid in all_uids:
     uid = uid[0]
     is_training = int(uid in df['uid'].astype(int).as_matrix())
     query = "UPDATE " + dbtable + " SET training=" + str(is_training) + " WHERE uid=" + str(uid) + ";"
-    main.dbinteract(query)
+    main.dbinteract(query, targetdb=targetdb)
 
 # algo. step 0:
 # demand individual QC tests have TPR/FPR > some threshold

--- a/catchall.py
+++ b/catchall.py
@@ -42,7 +42,7 @@ def amend(combo, df):
 options, remainder = getopt.getopt(sys.argv[1:], 't:d:n:o:h')
 targetdb = 'iquod.db'
 dbtable = 'iquod'
-outfile = 'catchall.json'
+outfile = 'htp.json'
 samplesize = None
 for opt, arg in options:
     if opt == '-d':

--- a/filter-db.py
+++ b/filter-db.py
@@ -1,10 +1,10 @@
-# usage: python filter-db.py <full table name> <filtered table name> <number of good / bad profiles to pick>
+# usage: python filter-db.py <full table name> <filtered table name> <number of good / bad profiles to pick> <db filename>
 
 import sys, sqlite3
 
-if len(sys.argv) == 4:
+if len(sys.argv) == 5:
 
-    conn = sqlite3.connect('iquod.db', isolation_level=None)
+    conn = sqlite3.connect(sys.argv[4], isolation_level=None)
     cur = conn.cursor()
 
     query = "DROP TABLE IF EXISTS " + sys.argv[2]

--- a/plot-roc.py
+++ b/plot-roc.py
@@ -78,13 +78,13 @@ def plotRow(row):
     pylab.savefig(dir + str(p.uid()) + '.png', bbox_inches='tight')
     plt.close()
 
-def plot_roc():
+def plot_roc(inputdb='iquod.db'):
 
     # get qc tests
     testNames = main.importQC('qctests')
 
     # connect to database
-    conn = sqlite3.connect('iquod.db', isolation_level=None)
+    conn = sqlite3.connect(inputdb, isolation_level=None)
     cur = conn.cursor()
 
     # extract matrix of test results and true flags into a dataframe

--- a/plot-roc.py
+++ b/plot-roc.py
@@ -78,13 +78,13 @@ def plotRow(row):
     pylab.savefig(dir + str(p.uid()) + '.png', bbox_inches='tight')
     plt.close()
 
-def plot_roc(inputdb='iquod.db'):
+def plot_roc(targetdb='iquod.db'):
 
     # get qc tests
     testNames = main.importQC('qctests')
 
     # connect to database
-    conn = sqlite3.connect(inputdb, isolation_level=None)
+    conn = sqlite3.connect(targetdb, isolation_level=None)
     cur = conn.cursor()
 
     # extract matrix of test results and true flags into a dataframe

--- a/qctests/EN_background_check.py
+++ b/qctests/EN_background_check.py
@@ -57,7 +57,7 @@ def run_qc(p, parameters):
     # Remove missing data points.
     iOK = (clim.mask == False) & (bgev.mask == False)
     if np.count_nonzero(iOK) == 0: 
-        record_parameters(p, bgStdLevels, bgevStdLevels, origLevels, ptLevels, bgLevels)
+        record_parameters(p, bgStdLevels, bgevStdLevels, origLevels, ptLevels, bgLevels, parameters)
         return qc
     clim = clim[iOK]
     bgev = bgev[iOK]
@@ -125,11 +125,11 @@ def run_qc(p, parameters):
             origLevels.append(iLevel)
             ptLevels.append(potm)
             bgLevels.append(climLevel)
-    record_parameters(p, bgStdLevels, bgevStdLevels, origLevels, ptLevels, bgLevels)
+    record_parameters(p, bgStdLevels, bgevStdLevels, origLevels, ptLevels, bgLevels, parameters)
 
     return qc
 
-def record_parameters(profile, bgStdLevels, bgevStdLevels, origLevels, ptLevels, bgLevels):
+def record_parameters(profile, bgStdLevels, bgevStdLevels, origLevels, ptLevels, bgLevels, parameters):
     # pack the parameter arrays into the enbackground table
     # for consumption by the buddy check
 
@@ -139,7 +139,7 @@ def record_parameters(profile, bgStdLevels, bgevStdLevels, origLevels, ptLevels,
     ptlevels = main.pack_array(ptLevels)
     bglevels = main.pack_array(bgLevels)
     query = "REPLACE INTO enbackground VALUES(?,?,?,?,?,?);"
-    main.dbinteract(query, [profile.uid(), bgstdlevels, bgevstdlevels, origlevels, ptlevels, bglevels])
+    main.dbinteract(query, [profile.uid(), bgstdlevels, bgevstdlevels, origlevels, ptlevels, bglevels], targetdb=parameters["db"])
 
 
 def findGridCell(p, gridLong, gridLat):
@@ -203,8 +203,8 @@ def readENBackgroundCheckAux():
 
 def loadParameters(parameterStore):
 
-    main.dbinteract("DROP TABLE IF EXISTS enbackground")
-    main.dbinteract("CREATE TABLE IF NOT EXISTS enbackground (uid INTEGER PRIMARY KEY, bgstdlevels BLOB, bgevstdlevels BLOB, origlevels BLOB, ptlevels BLOB, bglevels BLOB)")
+    main.dbinteract("DROP TABLE IF EXISTS enbackground", targetdb=parameterStore["db"])
+    main.dbinteract("CREATE TABLE IF NOT EXISTS enbackground (uid INTEGER PRIMARY KEY, bgstdlevels BLOB, bgevstdlevels BLOB, origlevels BLOB, ptlevels BLOB, bglevels BLOB)", targetdb=parameterStore["db"])
     parameterStore['enbackground'] = readENBackgroundCheckAux()
 
 

--- a/qctests/EN_constant_value_check.py
+++ b/qctests/EN_constant_value_check.py
@@ -16,7 +16,7 @@ def test(p, parameters):
     # Check if the QC of this profile was already done and if not
     # run the QC.
     query = 'SELECT en_constant_value_check FROM ' + parameters["table"] + ' WHERE uid = ' + str(p.uid()) + ';'
-    qc_log = main.dbinteract(query)
+    qc_log = main.dbinteract(query, targetdb=parameters["db"])
     qc_log = main.unpack_row(qc_log[0])
     if qc_log[0] is not None:
         return qc_log[0]

--- a/qctests/EN_increasing_depth_check.py
+++ b/qctests/EN_increasing_depth_check.py
@@ -17,7 +17,7 @@ def test(p, parameters):
     # Check if the QC of this profile was already done and if not
     # run the QC.
     query = 'SELECT en_increasing_depth_check FROM ' + parameters["table"] + ' WHERE uid = ' + str(p.uid()) + ';'
-    qc_log = main.dbinteract(query)
+    qc_log = main.dbinteract(query, targetdb=parameters["db"])
     qc_log = main.unpack_row(qc_log[0])
     if qc_log[0] is not None:
         return qc_log[0]

--- a/qctests/EN_spike_and_step_check.py
+++ b/qctests/EN_spike_and_step_check.py
@@ -21,14 +21,14 @@ def test(p, parameters, suspect=False):
     set to True the test instead returns suspect levels.
     """
     
-    return run_qc(p, suspect)
+    return run_qc(p, suspect, parameters)
 
-def run_qc(p, suspect):
+def run_qc(p, suspect, parameters):
 
     # check for pre-registered suspect tabulation, if that's what we want:
     if suspect:
         query = 'SELECT suspect FROM enspikeandstep WHERE uid = ' + str(p.uid()) + ';'
-        susp = main.dbinteract(query)
+        susp = main.dbinteract(query, targetdb=parameters["db"])
         if len(susp) > 0:
             return main.unpack_row(susp[0])[0]
             
@@ -103,7 +103,7 @@ def run_qc(p, suspect):
     # register suspects, if computed, to db
     if suspect:
         query = "REPLACE INTO enspikeandstep VALUES(?,?);"
-        main.dbinteract(query, [p.uid(), main.pack_array(qc)] )
+        main.dbinteract(query, [p.uid(), main.pack_array(qc)], targetdb=parameters["db"] )
 
     return qc
 
@@ -202,5 +202,5 @@ def interpolate(depth, shallow, deep, shallowVal, deepVal):
 
 def loadParameters(parameterStore):
 
-    main.dbinteract("DROP TABLE IF EXISTS enspikeandstep")
-    main.dbinteract("CREATE TABLE IF NOT EXISTS enspikeandstep (uid INTEGER PRIMARY KEY, suspect BLOB)")
+    main.dbinteract("DROP TABLE IF EXISTS enspikeandstep", targetdb=parameterStore["db"])
+    main.dbinteract("CREATE TABLE IF NOT EXISTS enspikeandstep (uid INTEGER PRIMARY KEY, suspect BLOB)", targetdb=parameterStore["db"])

--- a/qctests/EN_stability_check.py
+++ b/qctests/EN_stability_check.py
@@ -16,7 +16,7 @@ def test(p, parameters):
     # Check if the QC of this profile was already done and if not
     # run the QC.
     query = 'SELECT en_stability_check FROM ' + parameters["table"] + ' WHERE uid = ' + str(p.uid()) + ';'
-    qc_log = main.dbinteract(query)
+    qc_log = main.dbinteract(query, targetdb=parameters["db"])
     qc_log = main.unpack_row(qc_log[0])
     if qc_log[0] is not None:
         return qc_log[0]

--- a/qctests/EN_std_lev_bkg_and_buddy_check.py
+++ b/qctests/EN_std_lev_bkg_and_buddy_check.py
@@ -57,7 +57,7 @@ def test(p, parameters, allow_level_reinstating=True):
 
     # Check if we have found a buddy and process if so.
     if minDist <= 400000:
-        pBuddy = main.get_profile_from_db(profiles[iMinDist][0], parameters['table'])
+        pBuddy = main.get_profile_from_db(profiles[iMinDist][0], parameters['table'], parameters['db'])
 
         # buddy vetos
         Fail = False

--- a/qctests/EN_std_lev_bkg_and_buddy_check.py
+++ b/qctests/EN_std_lev_bkg_and_buddy_check.py
@@ -34,7 +34,7 @@ def test(p, parameters, allow_level_reinstating=True):
     # Retrieve the background and observation error variances and
     # the background values.
     query = 'SELECT bgstdlevels, bgevstdlevels FROM enbackground WHERE uid = ' + str(p.uid())
-    enbackground_pars = main.dbinteract(query)
+    enbackground_pars = main.dbinteract(query, targetdb=parameters["db"])
     enbackground_pars = main.unpack_row(enbackground_pars[0])
 
     bgsl = enbackground_pars[0]
@@ -73,7 +73,7 @@ def test(p, parameters, allow_level_reinstating=True):
           result = stdLevelData(pBuddy, parameters)
 
           query = 'SELECT bgevstdlevels FROM enbackground WHERE uid = ' + str(pBuddy.uid())
-          buddy_pars = main.dbinteract(query)
+          buddy_pars = main.dbinteract(query, targetdb=parameters["db"])
 
           buddy_pars = main.unpack_row(buddy_pars[0])
 
@@ -239,7 +239,7 @@ def stdLevelData(p, parameters):
     # Get the data stored by the EN background check.
     # As it was run above we know that the data is available in the db.
     query = 'SELECT origlevels, ptlevels, bglevels FROM enbackground WHERE uid = ' + str(p.uid())
-    enbackground_pars = main.dbinteract(query)
+    enbackground_pars = main.dbinteract(query, targetdb=parameters["db"])
     enbackground_pars = main.unpack_row(enbackground_pars[0])
     origlevels = enbackground_pars[0]
     ptlevels = enbackground_pars[1]
@@ -378,4 +378,4 @@ def get_profile_info(parameters):
     # Gets information about the profiles from the database.
 
     query = 'SELECT uid,year,month,cruise,lat,long FROM ' + parameters['table']
-    return main.dbinteract(query)
+    return main.dbinteract(query, targetdb=parameters["db"])

--- a/qctests/EN_std_lev_bkg_and_buddy_check.py
+++ b/qctests/EN_std_lev_bkg_and_buddy_check.py
@@ -57,7 +57,7 @@ def test(p, parameters, allow_level_reinstating=True):
 
     # Check if we have found a buddy and process if so.
     if minDist <= 400000:
-        pBuddy = main.get_profile_from_db(profiles[iMinDist][0])
+        pBuddy = main.get_profile_from_db(profiles[iMinDist][0], parameters['table'])
 
         # buddy vetos
         Fail = False

--- a/qctests/EN_track_check.py
+++ b/qctests/EN_track_check.py
@@ -69,7 +69,7 @@ def test(p, parameters):
     for i in range(len(track_rows)):
         result.append((main.pack_array(EN_track_results[track_rows[i][0]]), track_rows[i][0]))
 
-    query = "UPDATE " + sys.argv[1] + " SET en_track_check=? WHERE uid=?"
+    query = "UPDATE " + parameters['table'] + " SET en_track_check=? WHERE uid=?"
     main.interact_many(query, result)
     return EN_track_results[uid]
 

--- a/qctests/EN_track_check.py
+++ b/qctests/EN_track_check.py
@@ -26,7 +26,7 @@ def test(p, parameters):
 
     # don't bother if this has already been analyzed
     command = 'SELECT en_track_check FROM ' + parameters["table"] + ' WHERE uid = ' + str(uid) + ';'
-    en_track_result = main.dbinteract(command)
+    en_track_result = main.dbinteract(command, targetdb=parameters["db"])
     if en_track_result[0][0] is not None:
         en_track_result = main.unpack_row(en_track_result[0])[0]
         result = np.zeros(1, dtype=bool)
@@ -39,7 +39,7 @@ def test(p, parameters):
 
     # fetch all profiles on track, sorted chronologically, earliest first (None sorted as highest), then by uid
     command = 'SELECT uid, year, month, day, time, lat, long, probe, raw FROM ' + parameters["table"] + ' WHERE cruise = ' + str(cruise) + ' and country = "' + str(country) + '" and ocruise = "' + str(originator_cruise) + '" and year is not null and month is not null and day is not null and time is not null ORDER BY year, month, day, time, uid ASC;'
-    track_rows = main.dbinteract(command)
+    track_rows = main.dbinteract(command, targetdb=parameters["db"])
 
     # avoid inappropriate profiles
     track_rows = [tr for tr in track_rows if assess_usability_raw(tr[8][1:-1])]
@@ -70,7 +70,7 @@ def test(p, parameters):
         result.append((main.pack_array(EN_track_results[track_rows[i][0]]), track_rows[i][0]))
 
     query = "UPDATE " + parameters['table'] + " SET en_track_check=? WHERE uid=?"
-    main.interact_many(query, result)
+    main.interact_many(query, result, targetdb=parameters['db'])
     return EN_track_results[uid]
 
 #def sliceTrack(p, rows, margin=7):

--- a/qctests/ICDC_aqc_01_level_order.py
+++ b/qctests/ICDC_aqc_01_level_order.py
@@ -27,25 +27,25 @@ def test(p, parameters):
        negative depths.
     '''
     
-    uid, nlevels, origlevels, zr, tr, qc = level_order(p)
+    uid, nlevels, origlevels, zr, tr, qc = level_order(p, parameters)
 
     return qc
 
-def reordered_data(p):
+def reordered_data(p, parameters):
     '''Return number levels and depth, temperature in depth order.
        Only non-rejected levels are returned.
     '''
 
-    uid, nlevels, origlevels, zr, tr, qc = level_order(p)
+    uid, nlevels, origlevels, zr, tr, qc = level_order(p, parameters)
 
     return nlevels, zr, tr
 
-def revert_order(p, data):
+def revert_order(p, data, parameters):
     '''Return data in the original profile order. Data rejected in
        the level_order function are returned as missing data.
     '''
 
-    uid, nlevels, origlevels, zr, tr, qc = level_order(p)
+    uid, nlevels, origlevels, zr, tr, qc = level_order(p, parameters)
 
     datar      = np.ma.array(np.ndarray(p.n_levels()), 
                              dtype = data.dtype)
@@ -56,21 +56,21 @@ def revert_order(p, data):
 
     return datar
 
-def revert_qc_order(p, qc):
+def revert_qc_order(p, qc, parameters):
     '''Return QC array. Missing data values are set to False.'''
     
-    qcr = revert_order(p, qc)
+    qcr = revert_order(p, qc, parameters)
     qcr[qcr.mask] = False
     return qcr
 
-def level_order(p):
+def level_order(p, parameters):
     '''Reorders data into depth order and rejects levels with 
        negative depth.
     '''
     
     # check if the relevant info is already in the db
     query = 'SELECT nlevels, origlevels, zr, tr, qc FROM icdclevelorder WHERE uid = ' + str(p.uid())
-    precomputed = main.dbinteract(query)           
+    precomputed = main.dbinteract(query, targetdb=parameters["db"])
     if len(precomputed) > 0:
         nlevels = precomputed[0][0]
         origlevels = pickle.load(io.BytesIO(precomputed[0][1]))
@@ -112,11 +112,11 @@ def level_order(p):
     qc_p = pickle.dumps(qc, -1)
     
     query = "REPLACE INTO icdclevelorder VALUES(?,?,?,?,?,?)"
-    main.dbinteract(query, [p.uid(), nlevels, sqlite3.Binary(origlevels_p), sqlite3.Binary(zr_p), sqlite3.Binary(tr_p), sqlite3.Binary(qc_p)])
+    main.dbinteract(query, [p.uid(), nlevels, sqlite3.Binary(origlevels_p), sqlite3.Binary(zr_p), sqlite3.Binary(tr_p), sqlite3.Binary(qc_p)], targetdb=parameters["db"])
 
     return p.uid(), nlevels, origlevels, zr, tr, qc
 
 def loadParameters(parameterStore):
 
-    main.dbinteract("DROP TABLE IF EXISTS icdclevelorder")
-    main.dbinteract("CREATE TABLE IF NOT EXISTS icdclevelorder (uid INTEGER PRIMARY KEY, nlevels INTEGER, origlevels BLOB, zr BLOB, tr BLOB, qc BLOB)")
+    main.dbinteract("DROP TABLE IF EXISTS icdclevelorder", targetdb=parameterStore["db"])
+    main.dbinteract("CREATE TABLE IF NOT EXISTS icdclevelorder (uid INTEGER PRIMARY KEY, nlevels INTEGER, origlevels BLOB, zr BLOB, tr BLOB, qc BLOB)", targetdb=parameterStore["db"])

--- a/qctests/ICDC_aqc_02_crude_range.py
+++ b/qctests/ICDC_aqc_02_crude_range.py
@@ -23,7 +23,7 @@ def test(p, parameters):
     '''Return a set of QC decisions. 
     '''
     
-    nlevels, z, t = ICDC.reordered_data(p)
+    nlevels, z, t = ICDC.reordered_data(p, parameters)
 
     qc = (t < parminover) | (t > parmaxover)
 
@@ -36,7 +36,7 @@ def test(p, parameters):
                   (zval <= zcrude1) & (zval >= zcrude2)):
             qc[i] = True 
 
-    return ICDC.revert_qc_order(p, qc)
+    return ICDC.revert_qc_order(p, qc, parameters)
 
 # Ranges:
 tcrude1 = np.array(

--- a/qctests/ICDC_aqc_05_stuck_value.py
+++ b/qctests/ICDC_aqc_05_stuck_value.py
@@ -44,7 +44,7 @@ def test(p, parameters):
         return qc # Do not have the information to QC other types.
     
     # Check that we have the levels we need.
-    nlevels, z, t = ICDC.reordered_data(p)
+    nlevels, z, t = ICDC.reordered_data(p, parameters)
     if nlevels <= minlevs: return qc
     
     # Count stuck values.
@@ -63,7 +63,7 @@ def test(p, parameters):
         # If setting the QC flags we need to be careful about level order.
         qclo = qc[0:nlevels]
         qclo[i:i+n[i]] = True
-        qc = ICDC.revert_qc_order(p, qclo)
+        qc = ICDC.revert_qc_order(p, qclo, parameters)
 
     return qc
 

--- a/qctests/ICDC_aqc_06_n_temperature_extrema.py
+++ b/qctests/ICDC_aqc_06_n_temperature_extrema.py
@@ -32,7 +32,7 @@ def test(p, parameters):
     maxextre   = 4
 
     # Check that we have the levels we need.
-    nlevels, z, t = ICDC.reordered_data(p)
+    nlevels, z, t = ICDC.reordered_data(p, parameters)
     if nlevels <= levminext: return qc
 
     # Exclude data outside allowed range.

--- a/qctests/ICDC_aqc_07_spike_check.py
+++ b/qctests/ICDC_aqc_07_spike_check.py
@@ -25,7 +25,7 @@ def test(p, parameters):
     '''
     
     # The test is run on re-ordered data.
-    nlevels, z, t = ICDC.reordered_data(p)
+    nlevels, z, t = ICDC.reordered_data(p, parameters)
     qc = np.zeros(nlevels, dtype=bool) # Reordered data may be a subset of available levels.
     defaultqc = np.zeros(p.n_levels(), dtype=bool) # Default QC flags for full set of levels.
     if nlevels < 3: return defaultqc # Not enough levels to check.
@@ -70,7 +70,7 @@ def test(p, parameters):
     # Set QC flags.
     qc[ol[spike > spikemax]] = True
 
-    return ICDC.revert_qc_order(p, qc)
+    return ICDC.revert_qc_order(p, qc, parameters)
 
 
 

--- a/qctests/ICDC_aqc_08_gradient_check.py
+++ b/qctests/ICDC_aqc_08_gradient_check.py
@@ -28,7 +28,7 @@ def test(p, parameters):
     parmaxover = 33.0
 
     # The test is run on re-ordered data.
-    nlevels, z, t = ICDC.reordered_data(p)
+    nlevels, z, t = ICDC.reordered_data(p, parameters)
     qc = np.zeros(nlevels, dtype=bool)
 
     # Calculate gradients and thresholds.
@@ -57,7 +57,7 @@ def test(p, parameters):
         qc[result] = True
         qc[result + 1] = True
 
-    return ICDC.revert_qc_order(p, qc)
+    return ICDC.revert_qc_order(p, qc, parameters)
 
 
 

--- a/qctests/ICDC_aqc_09_local_climatology_check.py
+++ b/qctests/ICDC_aqc_09_local_climatology_check.py
@@ -38,7 +38,7 @@ def test(p, parameters):
     '''
     
     # The test is run on re-ordered data.
-    nlevels, z, t = ICDC.reordered_data(p)
+    nlevels, z, t = ICDC.reordered_data(p, parameters)
     
     # Define default QC.
     defaultqc = np.zeros(p.n_levels(), dtype=bool)
@@ -62,7 +62,7 @@ def test(p, parameters):
     tmin, tmax = ranges
     qc = ((t < tmin) | (t > tmax)) & (tmin != paramsicdc09['fillValue']) & (tmax != paramsicdc09['fillValue']) 
 
-    return ICDC.revert_qc_order(p, qc)
+    return ICDC.revert_qc_order(p, qc, parameters)
 
 def get_climatology_range(nlevels, z, lat, lon, month, paramsicdc09):
 

--- a/summarize-results.py
+++ b/summarize-results.py
@@ -1,23 +1,33 @@
-import sys
+import sys, getopt
 import util.dbutils as dbutils
 import util.main as main
 
 '''
 Prints a simple summary of true and false, postive and negative rates.
 
-Usage: python summarize-results.py databasetable
+Usage: python summarize-results.py -t <db filename> -d <table name>
 '''
 
-if len(sys.argv) == 2:
+# parse options
+options, remainder = getopt.getopt(sys.argv[1:], 't:d:h')
+targetdb = 'iquod.db'
+dbtable = 'iquod'
+for opt, arg in options:
+    if opt == '-d':
+        dbtable = arg
+    if opt == '-t':
+        targetdb = arg
+    if opt == '-h':
+        print('usage:')
+        print('-d <db table name to read from>')
+        print('-t <name of db file>')
+        print('-h print this help message and quit')
 
-    df        = dbutils.db_to_df(sys.argv[1])
-    testNames = df.columns[1:].values.tolist()
+df        = dbutils.db_to_df(sys.argv[1])
+testNames = df.columns[1:].values.tolist()
 
-    print('{0:>35s} {1:>7s} {2:>7s} {3:>7s} {4:>7s} {5:>7s}'.format('NAME OF TEST', 'FAILS', 'TPR', 'FPR', 'TNR', 'FNR'))
-    for test in testNames:
-       tpr, fpr, fnr, tnr = main.calcRates(df[test].tolist(), df['Truth'].tolist())
-       print('{0:>35s} {1:7d} {2:6.1f}{3:1s} {4:6.1f}{5:1s} {6:6.1f}{7:1s} {8:6.1f}{9:1s}'.format(test, sum(df[test].tolist()), tpr, '%', fpr, '%', tnr, '%', fnr, '%'))
+print('{0:>35s} {1:>7s} {2:>7s} {3:>7s} {4:>7s} {5:>7s}'.format('NAME OF TEST', 'FAILS', 'TPR', 'FPR', 'TNR', 'FNR'))
+for test in testNames:
+   tpr, fpr, fnr, tnr = main.calcRates(df[test].tolist(), df['Truth'].tolist())
+   print('{0:>35s} {1:7d} {2:6.1f}{3:1s} {4:6.1f}{5:1s} {6:6.1f}{7:1s} {8:6.1f}{9:1s}'.format(test, sum(df[test].tolist()), tpr, '%', fpr, '%', tnr, '%', fnr, '%'))
 
-else:
-
-    print('Usage: python summarize-results.py databasetable')

--- a/summarize-results.py
+++ b/summarize-results.py
@@ -23,7 +23,7 @@ for opt, arg in options:
         print('-t <name of db file>')
         print('-h print this help message and quit')
 
-df        = dbutils.db_to_df(sys.argv[1])
+df        = dbutils.db_to_df(table=dbtable, targetdb=targetdb)
 testNames = df.columns[1:].values.tolist()
 
 print('{0:>35s} {1:>7s} {2:>7s} {3:>7s} {4:>7s} {5:>7s}'.format('NAME OF TEST', 'FAILS', 'TPR', 'FPR', 'TNR', 'FNR'))

--- a/tests/EN_background_available_check_validation.py
+++ b/tests/EN_background_available_check_validation.py
@@ -9,6 +9,7 @@ import numpy
 class TestClass:
 
     parameters = {
+        'db': 'iquod.db',
         "table": 'unit'
     }
     qctests.EN_background_check.loadParameters(parameters)

--- a/tests/EN_background_check_validation.py
+++ b/tests/EN_background_check_validation.py
@@ -9,6 +9,7 @@ import numpy
 class TestClass:
 
     parameters = {
+        'db': 'iquod.db',
         "table": 'unit'
     }
     qctests.EN_background_check.loadParameters(parameters)

--- a/tests/EN_constant_value_check_validation.py
+++ b/tests/EN_constant_value_check_validation.py
@@ -9,6 +9,7 @@ import util.main as main
 class TestClass:
 
     parameters = {
+        'db': 'iquod.db',
         "table": 'unit'
     }
 

--- a/tests/EN_increasing_depth_check_validation.py
+++ b/tests/EN_increasing_depth_check_validation.py
@@ -8,6 +8,7 @@ import util.main as main
 class TestClass:
 
     parameters = {
+        'db': 'iquod.db',
         "table": 'unit'
     }
 

--- a/tests/EN_spike_and_step_check_validation.py
+++ b/tests/EN_spike_and_step_check_validation.py
@@ -8,6 +8,7 @@ import util.main as main
 class TestClass:
 
     parameters = {
+        'db': 'iquod.db',
         "table": 'unit'
     }
 

--- a/tests/EN_stability_check_validation.py
+++ b/tests/EN_stability_check_validation.py
@@ -9,6 +9,7 @@ import util.main as main
 class TestClass:
 
     parameters = {
+        'db': 'iquod.db',
         "table": 'unit'
     }
 

--- a/tests/EN_std_level_background_check_validation.py
+++ b/tests/EN_std_level_background_check_validation.py
@@ -19,7 +19,7 @@ def profile_to_info_list(p):
     '''
     return (p.uid(),p.year(),p.month(),p.cruise(),p.latitude(),p.longitude())
 
-def dummy_get_profile_from_db(uid):
+def dummy_get_profile_from_db(uid, table, targetdb):
     if uid == 1:
         return realProfile1
     elif uid == 2:
@@ -34,7 +34,8 @@ def dummy_get_profile_from_db(uid):
 class TestClass:
 
     parameters = {
-        "table": 'unit'
+        "table": 'unit',
+        "db": 'iquod.db'
     }
     qctests.EN_background_check.loadParameters(parameters)
 

--- a/tests/ICDC_aqc_01_level_order_validation.py
+++ b/tests/ICDC_aqc_01_level_order_validation.py
@@ -9,7 +9,10 @@ import numpy as np
 
 class TestClass:
 
-    parameters = {}
+    parameters = {
+        'db': 'iquod.db',
+        'table': 'unit'
+    }
 
     def setUp(self):
         # refresh this table every test
@@ -25,18 +28,18 @@ class TestClass:
                                             [2.0, -1.0, 1.0],
                                             uid=8888)
         qc              = ICDC.test(p, self.parameters)
-        nlevels, zr, tr = ICDC.reordered_data(p)
-        zreverted       = ICDC.revert_order(p, zr)    
-        zreverted_truth = np.ma.array([2.0, -1.0, 1.0], 
+        nlevels, zr, tr = ICDC.reordered_data(p, self.parameters)
+        zreverted       = ICDC.revert_order(p, zr, self.parameters)
+        zreverted_truth = np.ma.array([2.0, -1.0, 1.0],
                                       mask = [False, True, False])
-        
+
         assert np.array_equal(qc, [False, True, False]), 'QC error'
         assert nlevels == 2, 'Subsetting of levels incorrect'
         assert np.array_equal(zr, [1.0, 2.0]), 'Depth reorder failed'
         assert np.array_equal(tr, [3.0, 1.0]), 'Temperature reorder failed'
-        assert np.array_equal(zreverted.data[zreverted.mask == False],                       
+        assert np.array_equal(zreverted.data[zreverted.mask == False],
                               zreverted_truth.data[zreverted_truth.mask == False]),           'Revert data failed'
-        assert np.array_equal(zreverted.mask,                       
+        assert np.array_equal(zreverted.mask,
                               zreverted_truth.mask), 'Revert data failed'
 
     def test_ICDC_level_order(self):
@@ -64,7 +67,7 @@ class TestClass:
             assert np.array_equal(qc, qctruth), 'Example {} QC wrong'.format(i + 1)
 
             # Check that the reordering is correct.
-            nlevels, zr, tr = ICDC.reordered_data(p)
+            nlevels, zr, tr = ICDC.reordered_data(p, self.parameters)
             assert np.array_equal(zr, ztruth), 'Example {} zr wrong'.format(i + 1)
             assert np.array_equal(tr, ttruth), 'Example {} tr wrong'.format(i + 1)
 

--- a/tests/ICDC_aqc_02_crude_range_validation.py
+++ b/tests/ICDC_aqc_02_crude_range_validation.py
@@ -10,7 +10,10 @@ import numpy as np
 
 class TestClass:
 
-    parameters = {}
+    parameters = {
+        'db': 'iquod.db',
+        'table': 'unit'
+    }
 
     def setUp(self):
         # refresh this table every test

--- a/tests/ICDC_aqc_04_max_obs_depth_validation.py
+++ b/tests/ICDC_aqc_04_max_obs_depth_validation.py
@@ -10,7 +10,10 @@ import numpy as np
 
 class TestClass:
 
-    parameters = {}
+    parameters = {
+        'db': 'iquod.db',
+        'table': 'unit'
+    }
 
     def setUp(self):
         # refresh this table every test

--- a/tests/ICDC_aqc_05_stuck_value_validation.py
+++ b/tests/ICDC_aqc_05_stuck_value_validation.py
@@ -10,7 +10,10 @@ import numpy as np
 
 class TestClass:
 
-    parameters = {}
+    parameters = {
+        'db': 'iquod.db',
+        'table': 'unit'
+    }
 
     def setUp(self):
         # refresh this table every test

--- a/tests/ICDC_aqc_06_n_temperature_extrema_validation.py
+++ b/tests/ICDC_aqc_06_n_temperature_extrema_validation.py
@@ -9,7 +9,10 @@ import numpy as np
 ##### --------------------------------------------------
 class TestClass:
 
-    parameters = {}
+    parameters = {
+        'db': 'iquod.db',
+        'table': 'unit'
+    }
 
     def setUp(self):
         # refresh this table every test

--- a/tests/ICDC_aqc_07_spike_check_validation.py
+++ b/tests/ICDC_aqc_07_spike_check_validation.py
@@ -9,7 +9,10 @@ import numpy as np
 ##### --------------------------------------------------
 class TestClass:
 
-    parameters = {}
+    parameters = {
+        'db': 'iquod.db',
+        'table': 'unit'
+    }
 
     def setUp(self):
         # refresh this table every test

--- a/tests/ICDC_aqc_08_gradient_check_validation.py
+++ b/tests/ICDC_aqc_08_gradient_check_validation.py
@@ -9,7 +9,10 @@ import numpy as np
 ##### --------------------------------------------------
 class TestClass:
 
-    parameters = {}
+    parameters = {
+        'db': 'iquod.db',
+        'table': 'unit'
+    }
 
     def setUp(self):
         # refresh this table every test

--- a/tests/ICDC_aqc_09_local_climatology_check_validation.py
+++ b/tests/ICDC_aqc_09_local_climatology_check_validation.py
@@ -9,8 +9,11 @@ import numpy as np
 ##### --------------------------------------------------
 class TestClass:
 
-    parameters = {}
-    
+    parameters = {
+        'db': 'iquod.db',
+        'table': 'unit'
+    }
+
     def setUp(self):
         # refresh this table every test
         ICDC.loadParameters(self.parameters)
@@ -55,7 +58,7 @@ class TestClass:
                                                      date=[year,month,day,0],
                                                      uid=i)
 
-                nlevels, z, t = ICDC.reordered_data(p)
+                nlevels, z, t = ICDC.reordered_data(p, self.parameters)
                 lat           = p.latitude()
                 lon           = p.longitude()
                 tmin, tmax    = ICDC_lc.get_climatology_range(nlevels, 

--- a/tests/ICDC_aqc_10_local_climatology_check_validation.py
+++ b/tests/ICDC_aqc_10_local_climatology_check_validation.py
@@ -7,8 +7,11 @@ import numpy as np
 ##### --------------------------------------------------
 class TestClass():
 
-    parameters = {}
-    
+    parameters = {
+        'db': 'iquod.db',
+        'table': 'unit'
+    }
+
     def setUp(self):
         # refresh this table every test
         ICDC.loadParameters(self.parameters)

--- a/tests/WOD_range_check_validation.py
+++ b/tests/WOD_range_check_validation.py
@@ -10,7 +10,11 @@ def test_WOD_range_check_spotcheck():
     spot check the WOD_range_test
     '''
 
-    parameters = {}
+    parameters = {
+        'db': 'iquod.db',
+        'table': 'unit'
+    }
+
     qctests.WOD_range_check.loadParameters(parameters)
 
     # should just barely pass; temperatures at threshold for these depths

--- a/util/dbutils.py
+++ b/util/dbutils.py
@@ -84,10 +84,10 @@ def db_to_df(table,
              filter_on_wire_break_test=False, 
              filter_on_tests={},
              n_to_extract=numpy.iinfo(numpy.int32).max,
-             inputdb='iquod.db'):
+             targetdb='iquod.db'):
 
     '''
-    Reads the table from inputdb into a pandas dataframe.
+    Reads the table from targetdb into a pandas dataframe.
     If filter_on_wire_break_test is True, the results from that test are used to exclude
          levels below a wire break from the test results and the wire break test is not returned.
     filter_on_tests is a generalised form of filter_on_wire_break and is used to exclude results; it takes a list of
@@ -100,7 +100,7 @@ def db_to_df(table,
     testNames.sort()
 
     # connect to database
-    conn = sqlite3.connect(inputdb, isolation_level=None)
+    conn = sqlite3.connect(targetdb, isolation_level=None)
     cur = conn.cursor()
 
     # extract matrix of test results and true flags into a dataframe

--- a/util/dbutils.py
+++ b/util/dbutils.py
@@ -83,10 +83,11 @@ def unpack_qc_results(results):
 def db_to_df(table,
              filter_on_wire_break_test=False, 
              filter_on_tests={},
-             n_to_extract=numpy.iinfo(numpy.int32).max):
+             n_to_extract=numpy.iinfo(numpy.int32).max,
+             inputdb='iquod.db'):
 
     '''
-    Reads the table from iquod.db into a pandas dataframe.
+    Reads the table from inputdb into a pandas dataframe.
     If filter_on_wire_break_test is True, the results from that test are used to exclude
          levels below a wire break from the test results and the wire break test is not returned.
     filter_on_tests is a generalised form of filter_on_wire_break and is used to exclude results; it takes a list of
@@ -99,7 +100,7 @@ def db_to_df(table,
     testNames.sort()
 
     # connect to database
-    conn = sqlite3.connect('iquod.db', isolation_level=None)
+    conn = sqlite3.connect(inputdb, isolation_level=None)
     cur = conn.cursor()
 
     # extract matrix of test results and true flags into a dataframe

--- a/util/main.py
+++ b/util/main.py
@@ -127,12 +127,12 @@ def calcRates(testResults, trueResults):
 
   return tpr, fpr, fnr, tnr 
 
-def get_profile_from_db(uid):
+def get_profile_from_db(uid, table):
   '''
   Given a unique id found in the current database table, return the corresponding WodPy profile object.
   '''
 
-  command = 'SELECT * FROM ' + sys.argv[1] + ' WHERE uid = ' + str(uid)
+  command = 'SELECT * FROM ' + table + ' WHERE uid = ' + str(uid)
   row = dbinteract(command)
   profile = text2wod(row[0][0][1:-1])
   return profile

--- a/util/main.py
+++ b/util/main.py
@@ -127,13 +127,13 @@ def calcRates(testResults, trueResults):
 
   return tpr, fpr, fnr, tnr 
 
-def get_profile_from_db(uid, table):
+def get_profile_from_db(uid, table, targetdb):
   '''
   Given a unique id found in the current database table, return the corresponding WodPy profile object.
   '''
 
   command = 'SELECT * FROM ' + table + ' WHERE uid = ' + str(uid)
-  row = dbinteract(command)
+  row = dbinteract(command, targetdb=targetdb)
   profile = text2wod(row[0][0][1:-1])
   return profile
 
@@ -196,7 +196,7 @@ def dbinteract(command, values=[], tries=0, targetdb='iquod.db'):
     cur.close()
     conn.close()
     if tries < max_retry:
-      dbinteract(command, values, tries+1)
+      dbinteract(command, values, tries+1, targetdb=targetdb)
     else:
       print('database interaction failed after', max_retry, 'retries')
       return -1  

--- a/util/main.py
+++ b/util/main.py
@@ -167,7 +167,7 @@ def dictify(rows, keys):
 
   return dicts
 
-def dbinteract(command, values=[], tries=0, inputdb='iquod.db'):
+def dbinteract(command, values=[], tries=0, targetdb='iquod.db'):
   '''
   execute the given SQL command;
   catch errors and retry a maximum number of times;
@@ -175,7 +175,7 @@ def dbinteract(command, values=[], tries=0, inputdb='iquod.db'):
   
   max_retry = 100
 
-  conn = sqlite3.connect(inputdb, isolation_level=None, timeout=60)
+  conn = sqlite3.connect(targetdb, isolation_level=None, timeout=60)
   cur = conn.cursor()
   
   try:
@@ -201,13 +201,13 @@ def dbinteract(command, values=[], tries=0, inputdb='iquod.db'):
       print('database interaction failed after', max_retry, 'retries')
       return -1  
 
-def interact_many(query, values, tries=0, inputdb='iquod.db'):
+def interact_many(query, values, tries=0, targetdb='iquod.db'):
   # similar to dbinteract, but does executemany
   # intended exclusively for writes
 
   max_retry = 100
 
-  conn = sqlite3.connect(inputdb, isolation_level=None, timeout=60)
+  conn = sqlite3.connect(targetdb, isolation_level=None, timeout=60)
   cur = conn.cursor()
 
   try:

--- a/util/main.py
+++ b/util/main.py
@@ -172,12 +172,11 @@ def dbinteract(command, values=[], tries=0, targetdb='iquod.db'):
   execute the given SQL command;
   catch errors and retry a maximum number of times;
   '''
-  
-  max_retry = 100
 
+  max_retry = 100
   conn = sqlite3.connect(targetdb, isolation_level=None, timeout=60)
   cur = conn.cursor()
-  
+
   try:
     cur.execute(command, values)
     try:
@@ -224,7 +223,7 @@ def interact_many(query, values, tries=0, targetdb='iquod.db'):
     cur.close()
     conn.close()
     if tries < max_retry:
-      interact_many(query, values, tries+1)
+      interact_many(query, values, tries+1, targetdb=targetdb)
     else:
       print('excecutemany failed after', max_retry, 'retries')
       return -1

--- a/util/main.py
+++ b/util/main.py
@@ -167,7 +167,7 @@ def dictify(rows, keys):
 
   return dicts
 
-def dbinteract(command, values=[], tries=0):
+def dbinteract(command, values=[], tries=0, inputdb='iquod.db'):
   '''
   execute the given SQL command;
   catch errors and retry a maximum number of times;
@@ -175,7 +175,7 @@ def dbinteract(command, values=[], tries=0):
   
   max_retry = 100
 
-  conn = sqlite3.connect('iquod.db', isolation_level=None, timeout=60)
+  conn = sqlite3.connect(inputdb, isolation_level=None, timeout=60)
   cur = conn.cursor()
   
   try:
@@ -201,13 +201,13 @@ def dbinteract(command, values=[], tries=0):
       print('database interaction failed after', max_retry, 'retries')
       return -1  
 
-def interact_many(query, values, tries=0):
+def interact_many(query, values, tries=0, inputdb='iquod.db'):
   # similar to dbinteract, but does executemany
   # intended exclusively for writes
 
   max_retry = 100
 
-  conn = sqlite3.connect('iquod.db', isolation_level=None, timeout=60)
+  conn = sqlite3.connect(inputdb, isolation_level=None, timeout=60)
   cur = conn.cursor()
 
   try:


### PR DESCRIPTION
The original purpose of this work was to make the output locations of all files user-settable, so they could be targeted at mounted directories for ease of use with containerized executions of AutoQC. The least-messy way to do this was to refactor all scripts to use flags rather than positional arguments; this way order of parameters no longer matters, and we don't have to infer what mode we're running a script in by the number of parameters passed.

Besides that, it also became evident while working on this that `analyze-results.py` fails if all the qc tests in a given required set are eliminated for being nondiscriminating or not flagging any bad profiles; here I allow `analyze-results` to continue without picking anything from the class of tests in question in this case.

@s-good please let me know what you think of this approach, particularly with `analyze-results`.