### PR TITLE
Gross range check

### DIFF
--- a/qctest_groups.csv
+++ b/qctest_groups.csv
@@ -12,6 +12,7 @@ Range,At least one from group,CoTeDe_GTSPP_profile_envelop,
 Range,At least one from group,EN_range_check,
 Range,At least one from group,ICDC_aqc_02_crude_range,
 Range,Optional,ICDC_aqc_06_n_temperature_extrema,
+Range,Remove rejected levels,IQuOD_gross_range_check,Remove extreme outliers from further consideration
 Range,At least one from group,WOD_range_check,
 Gradient,At least one from group,AOML_gradient,
 Gradient,At least one from group,Argo_gradient_test,

--- a/qctests/IQuOD_gross_range_check.py
+++ b/qctests/IQuOD_gross_range_check.py
@@ -1,0 +1,24 @@
+""" 
+Implements a global range check used to filter out very obvious errors.
+"""
+
+from util import obs_utils
+
+def test(p, parameters):
+    """ 
+    Runs the quality control check on profile p and returns a numpy array 
+    of quality control decisions with False where the data value has 
+    passed the check and True where it failed. 
+    """
+
+    # Get temperature and pressure values from the profile.
+    t = p.t()
+
+    # Make the quality control decisions. This should
+    # return true if the temperature is outside -4 deg C
+    # and 100 deg C.
+    qc = (t.mask == False) & ((t.data < -4.0) | (t.data > 100.0))
+    
+    return qc
+
+

--- a/tests/IQuOD_gross_range_check_validation.py
+++ b/tests/IQuOD_gross_range_check_validation.py
@@ -1,0 +1,48 @@
+import qctests.IQuOD_gross_range_check
+import util.testingProfile
+import numpy
+from util import obs_utils
+
+##### IQuOD_gross_range_check ---------------------------------------------------
+
+def test_IQuOD_gross_range_check():
+    '''
+    Make sure the test is flagging temperature excursions
+    '''
+
+    # should fail despite rounding
+    p = util.testingProfile.fakeProfile([-4.000000001], [100]) 
+    qc = qctests.IQuOD_gross_range_check.test(p, None)
+    truth = numpy.zeros(1, dtype=bool)
+    truth[0] = True
+    assert numpy.array_equal(qc, truth), 'failed to flag temperature slightly colder than -4.0 C'
+
+    # -4.0 OK
+    p = util.testingProfile.fakeProfile([-4.0], [100]) 
+    qc = qctests.IQuOD_gross_range_check.test(p, None)
+    truth = numpy.zeros(1, dtype=bool)
+    assert numpy.array_equal(qc, truth), 'incorrectly flagging -4.0 C'
+
+    # 100.0 OK
+    p = util.testingProfile.fakeProfile([100], [100]) 
+    qc = qctests.IQuOD_gross_range_check.test(p, None)
+    truth = numpy.zeros(1, dtype=bool)
+    assert numpy.array_equal(qc, truth), 'incorrectly flagging 100 C'
+
+    # should fail despite rounding
+    p = util.testingProfile.fakeProfile([100.0000001], [100], latitude=0.0) 
+    qc = qctests.IQuOD_gross_range_check.test(p, None)
+    truth = numpy.zeros(1, dtype=bool)
+    truth[0] = True
+    assert numpy.array_equal(qc, truth), 'failed to flag temperature slightly warmer than 100 C'        
+
+    # test of a sequence of temperatures contained in a profile
+    p = util.testingProfile.fakeProfile([0.0, 20.0, -5.0, 16.0, 101.0], [0, 1, 2, 3, 4, 5], latitude=0.0) 
+    qc = qctests.IQuOD_gross_range_check.test(p, None)
+    truth = numpy.zeros(5, dtype=bool)
+    truth[2] = True
+    truth[4] = True
+    assert numpy.array_equal(qc, truth), 'failed to flag values in a profile'  
+    
+          
+


### PR DESCRIPTION
This check was suggested by @castelao as a pre-filter to remove gross outliers before the other QC checks are run. It is similar to other global range checks but has an extreme range so only obviously bad data are excluded.