### PR TITLE
Tidying up

### DIFF
--- a/AutoQC.py
+++ b/AutoQC.py
@@ -38,7 +38,7 @@ def process_row(uid, logdir, table='iquod', targetdb='iquod.db'):
       result = np.zeros(profile.n_levels(), dtype=bool)
 
     try:
-      query = "UPDATE " + table + " SET " + test + "=? WHERE uid=" + str(profile.uid()) + ";"
+      query = "UPDATE " + table + " SET " + test.lower() + "=? WHERE uid=" + str(profile.uid()) + ";"
       main.dbinteract(query, [main.pack_array(result)], targetdb=targetdb)
     except:
       print('db exception', sys.exc_info())

--- a/AutoQC.py
+++ b/AutoQC.py
@@ -35,7 +35,7 @@ def process_row(uid, logdir, table='iquod', targetdb='iquod.db'):
       result = run(test, [profile], parameterStore)[0]
     except:
       print(test, 'exception', sys.exc_info())
-      result = np.zeros(1, dtype=bool)
+      result = np.zeros(profile.n_levels(), dtype=bool)
 
     try:
       query = "UPDATE " + table + " SET " + test + "=? WHERE uid=" + str(profile.uid()) + ";"

--- a/qctests/AOML_spike.py
+++ b/qctests/AOML_spike.py
@@ -29,11 +29,11 @@ def spike(t):
     	return False
 
     centralTemp = t[int(len(t)/2)]
-    medianDiff = numpy.round( abs(centralTemp - numpy.median(t)),2)
+    medianDiff = numpy.round( abs(centralTemp - numpy.ma.median(t)),2)
 
     if medianDiff != 0:
         t = numpy.delete(t, int(len(t)/2))
-        spikeCheck = numpy.round(abs(centralTemp-numpy.mean(t)), 2)
+        spikeCheck = numpy.round(abs(centralTemp-numpy.ma.mean(t)), 2)
         if spikeCheck > 0.3:
             return True
 

--- a/qctests/Argo_impossible_date_test.py
+++ b/qctests/Argo_impossible_date_test.py
@@ -20,15 +20,15 @@ def test(p, parameters):
     time = p.time()
 
     # initialize qc as false:
-    qc = numpy.zeros(1, dtype=bool)
+    qc = numpy.zeros(p.n_levels(), dtype=bool)
 
     if year < 1700:
-        qc[0] = True
+        qc[:] = True
     elif month not in range(1,13):
-        qc[0] = True
+        qc[:] = True
     elif day not in range(1, calendar.monthrange(year, month)[1] + 1):
-        qc[0] = True
+        qc[:] = True
     elif time is not None and (time < 0 or time >= 24):
-        qc[0] = True
+        qc[:] = True
 
     return qc

--- a/qctests/Argo_impossible_location_test.py
+++ b/qctests/Argo_impossible_location_test.py
@@ -16,11 +16,11 @@ def test(p, parameters):
     longitude = p.longitude()
 
     # initialize qc as false:
-    qc = numpy.zeros(1, dtype=bool)
+    qc = numpy.zeros(p.n_levels(), dtype=bool)
 
     if isinstance(latitude, float) and latitude < -90 or latitude > 90:
-        qc[0] = True
+        qc[:] = True
     elif isinstance(longitude, float) and longitude < -180 or longitude > 180:
-        qc[0] = True
+        qc[:] = True
 
     return qc

--- a/qctests/EN_background_check.py
+++ b/qctests/EN_background_check.py
@@ -21,9 +21,10 @@ def test(p, parameters):
     # run the QC.
     #query = 'SELECT en_background_check FROM {} WHERE uid = {};'.format(parameters["table"], p.uid())
     #qc_log = main.dbinteract(query)
-    #if qc_log[0] is not None:
+    #if len(qc_log) > 0:
     #    qc_log = main.unpack_row(qc_log[0])
-    #    return qc_log[0]
+    #    if qc_log[0] is not None:
+    #        return qc_log[0]
 
     return run_qc(p, parameters)
 

--- a/qctests/EN_background_check.py
+++ b/qctests/EN_background_check.py
@@ -9,6 +9,7 @@ import numpy as np
 import util.obs_utils as outils
 from netCDF4 import Dataset
 import util.main as main
+from util.dbutils import retrieve_existing_qc_result
 
 def test(p, parameters):
     """
@@ -19,12 +20,12 @@ def test(p, parameters):
 
     # Check if the QC of this profile was already done and if not
     # run the QC.
-    #query = 'SELECT en_background_check FROM {} WHERE uid = {};'.format(parameters["table"], p.uid())
-    #qc_log = main.dbinteract(query)
-    #if len(qc_log) > 0:
-    #    qc_log = main.unpack_row(qc_log[0])
-    #    if qc_log[0] is not None:
-    #        return qc_log[0]
+    qc_log = retrieve_existing_qc_result('en_background_check', 
+                                         p.uid(),
+                                         parameters['table'], 
+                                         parameters['db'])
+    if qc_log is not None:
+        return qc_log
 
     return run_qc(p, parameters)
 

--- a/qctests/EN_background_check.py
+++ b/qctests/EN_background_check.py
@@ -21,9 +21,8 @@ def test(p, parameters):
     # run the QC.
     #query = 'SELECT en_background_check FROM {} WHERE uid = {};'.format(parameters["table"], p.uid())
     #qc_log = main.dbinteract(query)
-    #qc_log = main.unpack_row(qc_log[0])
-
     #if qc_log[0] is not None:
+    #    qc_log = main.unpack_row(qc_log[0])
     #    return qc_log[0]
 
     return run_qc(p, parameters)

--- a/qctests/EN_constant_value_check.py
+++ b/qctests/EN_constant_value_check.py
@@ -5,6 +5,7 @@ system, described on page 7 of http://www.metoffice.gov.uk/hadobs/en3/OQCpaper.p
 
 import numpy
 import util.main as main
+from util.dbutils import retrieve_existing_qc_result
 
 def test(p, parameters):
     """ 
@@ -15,12 +16,12 @@ def test(p, parameters):
 
     # Check if the QC of this profile was already done and if not
     # run the QC.
-    query = 'SELECT en_constant_value_check FROM ' + parameters["table"] + ' WHERE uid = ' + str(p.uid()) + ';'
-    qc_log = main.dbinteract(query, targetdb=parameters["db"])
-    if len(qc_log) > 0:
-        qc_log = main.unpack_row(qc_log[0])
-        if qc_log[0] is not None:
-            return qc_log[0]
+    qc_log = retrieve_existing_qc_result('en_constant_value_check', 
+                                         p.uid(),
+                                         parameters['table'], 
+                                         parameters['db'])
+    if qc_log is not None:
+        return qc_log
 
     return run_qc(p, parameters)
 

--- a/qctests/EN_constant_value_check.py
+++ b/qctests/EN_constant_value_check.py
@@ -17,8 +17,8 @@ def test(p, parameters):
     # run the QC.
     query = 'SELECT en_constant_value_check FROM ' + parameters["table"] + ' WHERE uid = ' + str(p.uid()) + ';'
     qc_log = main.dbinteract(query, targetdb=parameters["db"])
-    qc_log = main.unpack_row(qc_log[0])
     if qc_log[0] is not None:
+        qc_log = main.unpack_row(qc_log[0])
         return qc_log[0]
 
     return run_qc(p, parameters)

--- a/qctests/EN_constant_value_check.py
+++ b/qctests/EN_constant_value_check.py
@@ -17,9 +17,10 @@ def test(p, parameters):
     # run the QC.
     query = 'SELECT en_constant_value_check FROM ' + parameters["table"] + ' WHERE uid = ' + str(p.uid()) + ';'
     qc_log = main.dbinteract(query, targetdb=parameters["db"])
-    if qc_log[0] is not None:
+    if len(qc_log) > 0:
         qc_log = main.unpack_row(qc_log[0])
-        return qc_log[0]
+        if qc_log[0] is not None:
+            return qc_log[0]
 
     return run_qc(p, parameters)
 

--- a/qctests/EN_increasing_depth_check.py
+++ b/qctests/EN_increasing_depth_check.py
@@ -18,8 +18,8 @@ def test(p, parameters):
     # run the QC.
     query = 'SELECT en_increasing_depth_check FROM ' + parameters["table"] + ' WHERE uid = ' + str(p.uid()) + ';'
     qc_log = main.dbinteract(query, targetdb=parameters["db"])
-    qc_log = main.unpack_row(qc_log[0])
     if qc_log[0] is not None:
+        qc_log = main.unpack_row(qc_log[0])
         return qc_log[0]
 
     return run_qc(p, parameters)

--- a/qctests/EN_increasing_depth_check.py
+++ b/qctests/EN_increasing_depth_check.py
@@ -6,6 +6,7 @@ from . import EN_spike_and_step_check
 import numpy as np
 from collections import Counter
 import util.main as main
+from util.dbutils import retrieve_existing_qc_result
 
 def test(p, parameters):
     """
@@ -16,12 +17,12 @@ def test(p, parameters):
 
     # Check if the QC of this profile was already done and if not
     # run the QC.
-    query = 'SELECT en_increasing_depth_check FROM ' + parameters["table"] + ' WHERE uid = ' + str(p.uid()) + ';'
-    qc_log = main.dbinteract(query, targetdb=parameters["db"])
-    if len(qc_log) > 0:
-        qc_log = main.unpack_row(qc_log[0])
-        if qc_log[0] is not None:
-            return qc_log[0]
+    qc_log = retrieve_existing_qc_result('en_increasing_depth_check', 
+                                         p.uid(),
+                                         parameters['table'], 
+                                         parameters['db'])
+    if qc_log is not None:
+        return qc_log
         
     return run_qc(p, parameters)
 

--- a/qctests/EN_increasing_depth_check.py
+++ b/qctests/EN_increasing_depth_check.py
@@ -18,10 +18,11 @@ def test(p, parameters):
     # run the QC.
     query = 'SELECT en_increasing_depth_check FROM ' + parameters["table"] + ' WHERE uid = ' + str(p.uid()) + ';'
     qc_log = main.dbinteract(query, targetdb=parameters["db"])
-    if qc_log[0] is not None:
+    if len(qc_log) > 0:
         qc_log = main.unpack_row(qc_log[0])
-        return qc_log[0]
-
+        if qc_log[0] is not None:
+            return qc_log[0]
+        
     return run_qc(p, parameters)
 
 def mask_index(mat, index):

--- a/qctests/EN_stability_check.py
+++ b/qctests/EN_stability_check.py
@@ -17,9 +17,10 @@ def test(p, parameters):
     # run the QC.
     query = 'SELECT en_stability_check FROM ' + parameters["table"] + ' WHERE uid = ' + str(p.uid()) + ';'
     qc_log = main.dbinteract(query, targetdb=parameters["db"])
-    if qc_log[0] is not None:
+    if len(qc_log) > 0:
         qc_log = main.unpack_row(qc_log[0])
-        return qc_log[0]
+        if qc_log[0] is not None:
+            return qc_log[0]
         
     return run_qc(p, parameters)
 

--- a/qctests/EN_stability_check.py
+++ b/qctests/EN_stability_check.py
@@ -17,8 +17,8 @@ def test(p, parameters):
     # run the QC.
     query = 'SELECT en_stability_check FROM ' + parameters["table"] + ' WHERE uid = ' + str(p.uid()) + ';'
     qc_log = main.dbinteract(query, targetdb=parameters["db"])
-    qc_log = main.unpack_row(qc_log[0])
     if qc_log[0] is not None:
+        qc_log = main.unpack_row(qc_log[0])
         return qc_log[0]
         
     return run_qc(p, parameters)

--- a/qctests/EN_stability_check.py
+++ b/qctests/EN_stability_check.py
@@ -5,6 +5,7 @@ http://www.metoffice.gov.uk/hadobs/en3/OQCpaper.pdf
 
 import math, numpy
 import util.main as main
+from util.dbutils import retrieve_existing_qc_result
 
 def test(p, parameters):
     """ 
@@ -15,12 +16,12 @@ def test(p, parameters):
 
     # Check if the QC of this profile was already done and if not
     # run the QC.
-    query = 'SELECT en_stability_check FROM ' + parameters["table"] + ' WHERE uid = ' + str(p.uid()) + ';'
-    qc_log = main.dbinteract(query, targetdb=parameters["db"])
-    if len(qc_log) > 0:
-        qc_log = main.unpack_row(qc_log[0])
-        if qc_log[0] is not None:
-            return qc_log[0]
+    qc_log = retrieve_existing_qc_result('en_stability_check', 
+                                         p.uid(),
+                                         parameters['table'], 
+                                         parameters['db'])
+    if qc_log is not None:
+        return qc_log
         
     return run_qc(p, parameters)
 

--- a/qctests/EN_track_check.py
+++ b/qctests/EN_track_check.py
@@ -29,13 +29,13 @@ def test(p, parameters):
     en_track_result = main.dbinteract(command, targetdb=parameters["db"])
     if en_track_result[0][0] is not None:
         en_track_result = main.unpack_row(en_track_result[0])[0]
-        result = np.zeros(1, dtype=bool)
-        result[0] = np.any(en_track_result)
+        result = np.zeros(p.n_levels(), dtype=bool)
+        result[:] = np.any(en_track_result)
         return result
 
     # make sure this profile makes sense in the track check
     if not assess_usability(p):
-        return np.zeros(1, dtype=bool)
+        return np.zeros(p.n_levels(), dtype=bool)
 
     # fetch all profiles on track, sorted chronologically, earliest first (None sorted as highest), then by uid
     command = 'SELECT uid, year, month, day, time, lat, long, probe, raw FROM ' + parameters["table"] + ' WHERE cruise = ' + str(cruise) + ' and country = "' + str(country) + '" and ocruise = "' + str(originator_cruise) + '" and year is not null and month is not null and day is not null and time is not null ORDER BY year, month, day, time, uid ASC;'
@@ -47,7 +47,7 @@ def test(p, parameters):
     # start all as passing by default
     EN_track_results = {}
     for i in range(len(track_rows)):
-        EN_track_results[track_rows[i][0]] = np.zeros(1, dtype=bool)
+        EN_track_results[track_rows[i][0]] = np.zeros(p.n_levels(), dtype=bool)
 
     # copy the list of headers;
     # remove entries as they are flagged.
@@ -62,7 +62,7 @@ def test(p, parameters):
     # if more than half got rejected, reject everyone
     if len(passed_rows) < len(track_rows) / 2:
         for i in range(len(track_rows)):
-            EN_track_results[track_rows[i][0]][0] = True
+            EN_track_results[track_rows[i][0]][:] = True
 
     # write all to db
     result = []
@@ -164,7 +164,7 @@ def findOutlier(rows, results):
     if flag:
         rejects = chooseReject(rows, speeds, angles, iMax, maxSpeed)
         for reject in rejects:
-            results[rows[reject][0]][0] = True
+            results[rows[reject][0]][:] = True
         return rejects
     else:
         return []

--- a/qctests/minmax.py
+++ b/qctests/minmax.py
@@ -8,7 +8,12 @@ def test(p, parameters):
     temp_min, temp_max = extract_minmax(-obs_utils.depth_to_pressure(p.z(), p.latitude()), p.longitude(), p.latitude())
 
     # true flag if temp is out of range
-    qc = numpy.asarray([k<temp_min[i] or k>temp_max[i] for i,k in enumerate(temp)])
+    qc = numpy.zeros(p.n_levels(), dtype=bool)
+    for i, k in enumerate(temp):
+        # Only define a QC flag if all parameters are available.
+        if numpy.ma.is_masked(k) or numpy.isnan(temp_min[i]) or numpy.isnan(temp_max[i]): 
+            continue
+        qc[i] = (k<temp_min[i]) or (k>temp_max[i])
 
     return qc
 

--- a/tests/dbutils_validation.py
+++ b/tests/dbutils_validation.py
@@ -126,7 +126,7 @@ class TestClass:
         test = 'wod_range_check'
         retrieved_qc = retrieve_existing_qc_result(test, 8888, self.parameters['table'])
         
-        assert retrieved_qc is 343, 'None not returned if QC not available'
+        assert retrieved_qc is None, 'None not returned if QC not available'
         
 
         

--- a/tests/dbutils_validation.py
+++ b/tests/dbutils_validation.py
@@ -1,0 +1,132 @@
+import qctests.EN_background_check
+import qctests.EN_spike_and_step_check
+import qctests.EN_increasing_depth_check
+import qctests.EN_stability_check
+import qctests.EN_constant_value_check
+from util import main
+import util.testingProfile
+import numpy
+from util.dbutils import retrieve_existing_qc_result
+
+#####  ---------------------------------------------------
+
+class TestClass:
+
+    parameters = {
+        'db': 'iquod.db',
+        "table": 'unit'
+    }
+    qctests.EN_background_check.loadParameters(parameters)
+
+    def setUp(self):
+        # this qc test will go looking for the profile in question in the db, needs to find something sensible
+        main.faketable('unit')
+        main.fakerow('unit')
+        # need to re-do this every time to refresh the enspikeandstep table
+        qctests.EN_spike_and_step_check.loadParameters(self.parameters)
+
+    def tearDown(self):
+        main.dbinteract('DROP TABLE unit;')
+
+    def test_retrieve_existing_qc_results_EN_background(self):
+        '''
+        Use one of the EN_background_check tests to check retrieve_existing_qc_results is working.
+        '''
+        
+        test = 'en_background_check'
+        
+        # Create the test profile, run the QC check and save the result.
+        # Expected result is [False, False, False, True].
+        p = util.testingProfile.fakeProfile([1.8, 1.8, 1.8, 7.1], [0.0, 2.5, 5.0, 7.5], latitude=55.6, longitude=12.9, date=[1900, 1, 15, 0], probe_type=7, uid=8888) 
+        qc = qctests.EN_background_check.test(p, self.parameters)
+        query = "UPDATE " + self.parameters['table'] + " SET " + test + "=? WHERE uid=8888;"
+        main.dbinteract(query, [main.pack_array(qc)], targetdb=self.parameters['db'])
+        
+        # Use the retrieve_existing_qc_result to read the result back from the database.
+        retrieved_qc = retrieve_existing_qc_result(test, 8888, self.parameters['table'], self.parameters['db'])
+        assert numpy.array_equal(qc, retrieved_qc), 'mismatch between qc results and retrieved values'
+
+        # Also check against the expected result in case of database write/read mistake.
+        expected = numpy.array([False, False, False, True])
+        assert numpy.array_equal(expected, retrieved_qc), 'mismatch between expected and retrieved values'
+
+
+    def test_retrieve_existing_qc_results_EN_increasing_depth(self):
+        '''
+        Use one of the EN_increasing_depth tests to check retrieve_existing_qc_results is working.
+        '''
+        
+        test = 'en_increasing_depth_check'
+        
+        # Create the test profile, run the QC check and save the result.
+        # Expected result is [False, False, False, True, True, False, False, False, False, False].
+        p = util.testingProfile.fakeProfile([0,0,0,0,0,0,0,0,0,0], [100,200,300,500,500,600,700,800,900,1000], latitude=0.0, uid=8888)
+        qc = qctests.EN_increasing_depth_check.test(p, self.parameters)
+        query = "UPDATE " + self.parameters['table'] + " SET " + test + "=? WHERE uid=8888;"
+        main.dbinteract(query, [main.pack_array(qc)], targetdb=self.parameters['db'])
+        
+        # Use the retrieve_existing_qc_result to read the result back from the database.
+        retrieved_qc = retrieve_existing_qc_result(test, 8888, self.parameters['table'])     
+        assert numpy.array_equal(qc, retrieved_qc), 'mismatch between qc results and retrieved values'
+        
+        # Also check against the expected result in case of database write/read mistake.
+        expected = numpy.array([False, False, False, True, True, False, False, False, False, False])
+        assert numpy.array_equal(expected, retrieved_qc), 'mismatch between expected and retrieved values'
+
+        
+    def test_retrieve_existing_qc_results_EN_stability_check(self):
+        '''
+        Use one of the EN_stability_check tests to check retrieve_existing_qc_results is working.
+        '''
+        
+        test = 'en_stability_check'
+        
+        # Create the test profile, run the QC check and save the result.
+        # Expected result is [False, True, True, False, False, False, False, False, False].
+        p = util.testingProfile.fakeProfile([13.5, 25.5, 20.4, 13.5, 13.5, 13.5, 13.5, 13.5, 13.5], [0, 10, 20, 30, 40, 50, 60, 70, 80], salinities=[40, 35, 20, 40, 40, 40, 40, 40, 40], pressures=[8000, 2000, 1000, 8000, 8000, 8000, 8000, 8000, 8000], uid=8888)
+        qc = qctests.EN_stability_check.test(p, self.parameters)
+        query = "UPDATE " + self.parameters['table'] + " SET " + test + "=? WHERE uid=8888;"
+        main.dbinteract(query, [main.pack_array(qc)], targetdb=self.parameters['db'])
+        
+        # Use the retrieve_existing_qc_result to read the result back from the database.
+        retrieved_qc = retrieve_existing_qc_result(test, 8888, self.parameters['table'])       
+        assert numpy.array_equal(qc, retrieved_qc), 'mismatch between qc results and retrieved values'
+
+        # Also check against the expected result in case of database write/read mistake.
+        expected = numpy.array([False, True, True, False, False, False, False, False, False])
+        assert numpy.array_equal(expected, retrieved_qc), 'mismatch between expected and retrieved values'
+
+    def test_retrieve_existing_qc_results_EN_constant_value(self):
+        '''
+        Use one of the EN_constant_value_check tests to check retrieve_existing_qc_results is working.
+        '''
+        
+        test = 'en_constant_value_check'
+        
+        # Create the test profile, run the QC check and save the result.
+        # Expected result is [True, True, True, True, True, True, True, True, True, True].
+        p = util.testingProfile.fakeProfile([0,0,0,0,0,0,0,0,0,0], [100,200,300,400,500,600,700,800,900,None], uid=8888)
+        qc = qctests.EN_constant_value_check.test(p, self.parameters)
+        query = "UPDATE " + self.parameters['table'] + " SET " + test + "=? WHERE uid=8888;"
+        main.dbinteract(query, [main.pack_array(qc)], targetdb=self.parameters['db'])
+        
+        # Use the retrieve_existing_qc_result to read the result back from the database.
+        retrieved_qc = retrieve_existing_qc_result(test, 8888, self.parameters['table']) 
+        assert numpy.array_equal(qc, retrieved_qc), 'mismatch between qc results and retrieved values'
+
+        # Also check against the expected result in case of database write/read mistake.
+        expected = numpy.array([True, True, True, True, True, True, True, True, True, True])
+        assert numpy.array_equal(expected, retrieved_qc), 'mismatch between expected and retrieved values'
+
+    def test_retrieve_existing_qc_result_before_qc(self):
+        '''
+        Test that None is returned if a QC result has not been saved in the database.
+        '''
+        
+        test = 'wod_range_check'
+        retrieved_qc = retrieve_existing_qc_result(test, 8888, self.parameters['table'])
+        
+        assert retrieved_qc is 343, 'None not returned if QC not available'
+        
+
+        

--- a/util/dbutils.py
+++ b/util/dbutils.py
@@ -192,3 +192,34 @@ def db_to_df(table,
             df_final = pandas.concat([df_final, df])
 
     return df_final.reset_index(drop=True)
+    
+def retrieve_existing_qc_result(test, uid, table='iquod', db='iquod.db'):
+    '''
+    Extracts QC results from the d:
+    test  - the QC check to get results for.
+    uid   - the profile unique ID to get results for.
+    table - the database table for the profile.
+    db    - the name of the database file.
+    '''
+    
+    query = 'SELECT {} FROM {} WHERE uid = {};'.format(test, table, uid)
+    qc_log = main.dbinteract(query, targetdb=db)
+    try:
+        if len(qc_log) > 0:
+            qc_log = main.unpack_row(qc_log[0])
+            if qc_log[0] is not None:
+                return qc_log[0]
+        else:
+            print('Profile does not seem to exist in the database'
+            print(query)
+            print(qc_log)
+            raise
+    except:
+        print('Test name does not seem to exist in the database')
+        print(query)
+        print(qc_log)
+        
+    # If this point is reached, we just return None.
+    return None
+    
+

--- a/util/dbutils.py
+++ b/util/dbutils.py
@@ -201,20 +201,27 @@ def retrieve_existing_qc_result(test, uid, table='iquod', db='iquod.db'):
     table - the database table for the profile.
     db    - the name of the database file.
     '''
+
+    # The query below has three possible outcomes:
+    # 1) Returns a NoneType object if the test name does not exist. This is
+    #    caught as an error when the len(qc_log) command is run which then fails
+    #    in the except structure.
+    # 2) Returns an empty list if the profile does not exist in the database.
+    #    The code passes the try/except commands and fails at the end.
+    # 3) Returns a list containing either None if the QC results haven't been
+    #    stored or the QC results themselves, which are then returned.
     
     query = 'SELECT {} FROM {} WHERE uid = {};'.format(test, table, uid)
     qc_log = main.dbinteract(query, targetdb=db)
     try:
         if len(qc_log) > 0:
             qc_log = main.unpack_row(qc_log[0])
-            print('QC results extracted from database:')
-            print(query)
-            print(qc_log)
             return qc_log[0]
     except:
         print('***** Test name does not seem to exist in the database')
         print(query)
         print(qc_log)
+        raise
 
     # If this point has been reached it means that the profile does not exist.
     print('***** Profile does not seem to exist in the database')

--- a/util/dbutils.py
+++ b/util/dbutils.py
@@ -207,19 +207,19 @@ def retrieve_existing_qc_result(test, uid, table='iquod', db='iquod.db'):
     try:
         if len(qc_log) > 0:
             qc_log = main.unpack_row(qc_log[0])
-            if qc_log[0] is not None:
-                return qc_log[0]
-        else:
-            print('Profile does not seem to exist in the database'
+            print('QC results extracted from database:')
             print(query)
             print(qc_log)
-            raise
+            return qc_log[0]
     except:
-        print('Test name does not seem to exist in the database')
+        print('***** Test name does not seem to exist in the database')
         print(query)
         print(qc_log)
-        
-    # If this point is reached, we just return None.
-    return None
+
+    # If this point has been reached it means that the profile does not exist.
+    print('***** Profile does not seem to exist in the database')
+    print(query)
+    print(qc_log)
+    raise
     
 


### PR DESCRIPTION
This pull request does some tidying in preparation for our production run:

- Remove warning message in AOML_spike.py due to using numpy.median on a masked array (the mask is already checked for missing data prior to the use of numpy.median so the warning message is not useful). Using numpy.ma.median prevents the warning being printed. Numpy.ma.mean was also used in place of numpy.mean, but I don't think this was giving warnings.
- Try to make all tests return a QC result for all levels. Some QC tests such as the track check were just returning a single value, which is inconsistent with what most of the tests are doing.
- Fix an issue that was occurring for the EN_std_level_bkg_and_buddy_check, which tries to use previously cached results from other tests. The code wasn't checking whether the result was present properly, causing the check to fail.
- Prevent a warning from the minmax test due to the presence of NaNs in the arrays. I have changed the code to check that the temperature, min and max are all present before attempting to make a QC decision and defaulting to a pass result if not.