### PR TITLE
Further tidying

### DIFF
--- a/qctests/AOML_gradient.py
+++ b/qctests/AOML_gradient.py
@@ -17,7 +17,9 @@ def test(p, parameters):
 
     for i in range(p.n_levels()-1):
         if isData[i] and isData[i+1]:
-            gradTest = (t[i+1]-t[i]) / (z[i+1]-z[i])
+            dz = z[i+1]-z[i]
+            if dz == 0.0: continue
+            gradTest = (t[i+1]-t[i]) / dz
             if t[i+1]-t[i] < 0:
                 if abs(gradTest) > 1.0:
                     qc[i] = True

--- a/qctests/EN_background_check.py
+++ b/qctests/EN_background_check.py
@@ -204,7 +204,6 @@ def readENBackgroundCheckAux():
 
 def loadParameters(parameterStore):
 
-    main.dbinteract("DROP TABLE IF EXISTS enbackground", targetdb=parameterStore["db"])
     main.dbinteract("CREATE TABLE IF NOT EXISTS enbackground (uid INTEGER PRIMARY KEY, bgstdlevels BLOB, bgevstdlevels BLOB, origlevels BLOB, ptlevels BLOB, bglevels BLOB)", targetdb=parameterStore["db"])
     parameterStore['enbackground'] = readENBackgroundCheckAux()
 

--- a/qctests/EN_spike_and_step_check.py
+++ b/qctests/EN_spike_and_step_check.py
@@ -202,5 +202,4 @@ def interpolate(depth, shallow, deep, shallowVal, deepVal):
 
 def loadParameters(parameterStore):
 
-    main.dbinteract("DROP TABLE IF EXISTS enspikeandstep", targetdb=parameterStore["db"])
     main.dbinteract("CREATE TABLE IF NOT EXISTS enspikeandstep (uid INTEGER PRIMARY KEY, suspect BLOB)", targetdb=parameterStore["db"])

--- a/qctests/ICDC_aqc_01_level_order.py
+++ b/qctests/ICDC_aqc_01_level_order.py
@@ -118,5 +118,4 @@ def level_order(p, parameters):
 
 def loadParameters(parameterStore):
 
-    main.dbinteract("DROP TABLE IF EXISTS icdclevelorder", targetdb=parameterStore["db"])
     main.dbinteract("CREATE TABLE IF NOT EXISTS icdclevelorder (uid INTEGER PRIMARY KEY, nlevels INTEGER, origlevels BLOB, zr BLOB, tr BLOB, qc BLOB)", targetdb=parameterStore["db"])

--- a/tests/EN_spike_and_step_check_validation.py
+++ b/tests/EN_spike_and_step_check_validation.py
@@ -68,7 +68,7 @@ class TestClass:
         '''
         test preliminary tropical rejection
         '''
-        p = util.testingProfile.fakeProfile([0, 0, 0, 0], [0, 10, 20, 30], latitude=0.0, uid=8888)
+        p = util.testingProfile.fakeProfile([0, 0, 0, 0], [0, 10, 20, 30], latitude=0.0, uid=2222)
         qc = qctests.EN_spike_and_step_check.test(p, self.parameters, True)
         truth = numpy.zeros(4, dtype=bool)
         truth[:] = True
@@ -188,7 +188,7 @@ class TestClass:
         test condition C step check in context
         suspect == True since condition C is a suspected reject
         '''
-        p = util.testingProfile.fakeProfile([24, 24, 2, 1], [10, 20, 30, 40], latitude=20.0, uid=8888)
+        p = util.testingProfile.fakeProfile([24, 24, 2, 1], [10, 20, 30, 40], latitude=20.0, uid=1111)
         qc = qctests.EN_spike_and_step_check.test(p, self.parameters, True)
         truth = numpy.zeros(4, dtype=bool)
         truth[1] = True


### PR DESCRIPTION
Two changes to remove warnings/errors during productions runs:

1. Check for zero depth change in AOML_gradient to avoid divide by zero. I wasn't sure what to do in this situation, but went with setting the QC check to ignore pairs of levels with zero depth change as there are other QC checks that are designed to deal with this kind of problem.
2. Remove dropping of tables that store data produced by QC checks such as EN_background. This causes problems if running in batches as it deletes results from previous batches that are needed by the EN_std_level_bkg_and_buddy_check.

During investigating 2 I noticed something about the util/main.dbinteract function, which is that it doesn't call the database commit function. According to the sqlite3 documentation, this is needed else changes made to the database are not saved (https://docs.python.org/3/library/sqlite3.html). This is used in build-db.py but never when running AutoQC.py. Yet, clearly the results are being saved to the database, so maybe I don't understand this properly. @BillMills what do you think?