### PR TITLE
Fix issues handling times

### DIFF
--- a/cotede_qc/cotede_test.py
+++ b/cotede_qc/cotede_test.py
@@ -38,9 +38,6 @@ def get_qc(p, config, test):
                 test not in cotede_results[2] or
                    p.uid() is None):
         inputs = Wod4CoTeDe(p)
-        dt = inputs.attributes['datetime']
-        if dt.year < 1900:
-           inputs.attributes['datetime'] = dt.replace(year=1900)
 
         # If config is a dictionary, use it.
         if not isinstance(config, dict):

--- a/qctests/EN_std_lev_bkg_and_buddy_check.py
+++ b/qctests/EN_std_lev_bkg_and_buddy_check.py
@@ -355,6 +355,8 @@ def timeDiff(p1, p2):
         year  = prof.year()
         month = prof.month()
         day   = prof.day()
+        if (year is None) or (month is None) or (day is None):
+            return None
         if not (year > 0) or not (1 <= month <= 12) or not (1 <= day <= 31):
             return None 
         time  = prof.time()


### PR DESCRIPTION
Two fixes to prevent errors if there are missing values in the date information provided with a profile:

- Remove testing for year < 1900 in cotede_qc.py. Looking back into the code history, this was included because datetime.datetime.strftime could not handle dates before 1900, but as stated [here](https://docs.python.org/3/library/datetime.html#technical-detail) it has been able to do this since version 3.3. Therefore, we can safely remove these lines of code since AutoQC is using Python 3.6.
- In EN_std_level... check that year, month and date are not None before comparing them to integers.