### PR TITLE
Production2021 updates

### DIFF
--- a/analyse-results.py
+++ b/analyse-results.py
@@ -376,6 +376,17 @@ def find_roc_ordered(table,
                                   n_to_extract = n_profiles_to_analyse,
                                   pad=2, 
                                   XBTbelow=True)
+
+            # Drop nondiscriminating tests i.e. those that flag all or none
+            # of the profiles.
+            nondiscrim = []
+            cols = list(df.columns)
+            for c in cols:
+                if len(pandas.unique(df[c])) == 1:
+                    nondiscrim.append(c)
+                    if verbose: print(c + ' is nondiscriminating and will be removed')
+            cols = [t for t in cols if t not in nondiscrim]
+            df = df[cols]
             testNames = df.columns[2:].values.tolist()
             
             # Convert to numpy structures and save copy if first iteration.
@@ -456,7 +467,7 @@ def find_roc_ordered(table,
         for itest, name in enumerate(allnames):
             if tn == name:
                 cumulative         = np.logical_or(cumulative, alltests[itest])
-                tpr, fpr, fnr, tnr = main.calcRates(cumulative, truth)      
+                tpr, fpr, fnr, tnr = main.calcRates(cumulative, alltruth)      
                 r_fprs.append(fpr)
                 r_tprs.append(tpr)
                 print('ROC point: ', tpr, fpr, tn)

--- a/analyse-results.py
+++ b/analyse-results.py
@@ -498,7 +498,7 @@ def find_roc_ordered(table,
 if __name__ == '__main__':
 
     # parse options
-    options, remainder = getopt.getopt(sys.argv[1:], 't:d:n:c:o:p:h:sl')
+    options, remainder = getopt.getopt(sys.argv[1:], 't:d:n:c:o:p:hsl')
     targetdb = 'iquod.db'
     dbtable = 'iquod'
     outfile = False
@@ -543,4 +543,3 @@ if __name__ == '__main__':
         find_roc_ordered(table=dbtable, targetdb=targetdb, n_profiles_to_analyse=samplesize, costratio=costratio, plot_roc=plotfile, write_roc=outfile, levelbased=levelbased)
     else:
         find_roc(table=dbtable, targetdb=targetdb, n_profiles_to_analyse=samplesize, costratio=costratio, plot_roc=plotfile, write_roc=outfile)
-

--- a/analyse-results.py
+++ b/analyse-results.py
@@ -383,13 +383,13 @@ def find_roc_ordered(table,
                                   XBTbelow=True)
 
             # mark chosen profiles as part of the training set 
-            all_uids = main.dbinteract('SELECT uid from ' + table + ';', targetdb=targetdb)
             if mark_training:
-            for uid in all_uids:
-                uid = uid[0]
-                is_training = int(uid in df['uid'].astype(int).to_numpy())
-                query = "UPDATE " + table + " SET training=" + str(is_training) + " WHERE uid=" + str(uid) + ";"
-                main.dbinteract(query, targetdb=targetdb)
+                all_uids = main.dbinteract('SELECT uid from ' + table + ';', targetdb=targetdb)
+                for uid in all_uids:
+                    uid = uid[0]
+                    is_training = int(uid in df['uid'].astype(int).to_numpy())
+                    query = "UPDATE " + table + " SET training=" + str(is_training) + " WHERE uid=" + str(uid) + ";"
+                    main.dbinteract(query, targetdb=targetdb)
 
             # Drop nondiscriminating tests i.e. those that flag all or none
             # of the profiles.

--- a/analyse-results.py
+++ b/analyse-results.py
@@ -110,7 +110,10 @@ def find_roc(table,
                           targetdb = targetdb,
                           filter_on_wire_break_test = filter_on_wire_break_test,
                           filter_on_tests = groupdefinition,
-                          n_to_extract = n_profiles_to_analyse)
+                          n_to_extract = n_profiles_to_analyse,
+                          pad=2, 
+                          XBTbelow=True,
+                          mark_training=False)
 
     # Drop nondiscriminating tests
     nondiscrim = []
@@ -130,15 +133,16 @@ def find_roc(table,
 
     # mark chosen profiles as part of the training set 
     all_uids = main.dbinteract('SELECT uid from ' + table + ';', targetdb=targetdb)
-    for uid in all_uids:
-        uid = uid[0]
-        is_training = int(uid in df['uid'].astype(int).as_matrix())
-        query = "UPDATE " + table + " SET training=" + str(is_training) + " WHERE uid=" + str(uid) + ";"
-        main.dbinteract(query, targetdb=targetdb)
+    if mark_training:
+        for uid in all_uids:
+            uid = uid[0]
+            is_training = int(uid in df['uid'].astype(int).to_numpy())
+            query = "UPDATE " + table + " SET training=" + str(is_training) + " WHERE uid=" + str(uid) + ";"
+            main.dbinteract(query, targetdb=targetdb)
 
     # Convert to numpy structures and make inverse versions of tests if required.
     # Any test with true positive rate of zero is discarded.
-    truth = df['Truth'].as_matrix()
+    truth = df['Truth'].to_numpy()
     tests = []
     names = []
     tprs  = []
@@ -149,7 +153,7 @@ def find_roc(table,
         reverselist = [False]
     for i, testname in enumerate(testNames):
         for reversal in reverselist:
-            results = df[testname].as_matrix() != reversal
+            results = df[testname].to_numpy() != reversal
             tpr, fpr, fnr, tnr = main.calcRates(results, truth)
             if tpr > 0.0:
                 tests.append(results)
@@ -317,16 +321,181 @@ def find_roc(table,
         json.dump(r, f)
         f.close()
 
+def find_roc_ordered(table,
+                     targetdb,
+                     costratio=[2.5, 1.0],
+                     n_profiles_to_analyse=np.iinfo(np.int32).max,
+                     improve_threshold=1.0, 
+                     verbose=True, 
+                     plot_roc=True,
+                     write_roc=True,
+                     levelbased=False):
+    '''
+    Finds optimal tests to include in a QC set.
+    table - the database table to read;
+    targetdb - the datable file;
+    n_profiles_to_analyse - how many profiles to read from the database;
+    improve_threshold - how much improvement in true positive rate is needed
+                        for a test to be accepted once all groups have been done;
+    verbose - controls whether messages on progress are output;
+    plot_roc - controls is a plot is generated;
+    write_roc - controls whether a text file is generated;
+    levelbased - controls whether the database is re-read on each iteration of the
+                 processing; if False then profiles are not considered again
+                 once an accepted test has flagged them; if True, the levels that
+                 are flagged are removed so other problems in the profile can be
+                 used to determine the best quality control checks to use.
+    '''
+
+    # Define the order of tests.
+    ordering = ['Location', 'Range', 'Climatology', 'Increasing depth', 'Constant values',
+'Spike or step', 'Gradient', 'Density']
+
+    # Read QC test specifications.
+    groupdefinition = read_qc_groups()
+
+    # Create results list.
+    qclist = []
+
+    keepgoing = True
+    iit       = 0
+    while keepgoing:
+        if iit < len(ordering):
+            grouptofind = ordering[iit]
+        else:
+            grouptofind = 'any'
+        if verbose: print('-- Iteration ', iit + 1, ' to find test of type ', grouptofind)
+        
+        if (iit == 0) or levelbased:
+            if verbose: print('---- Running database read')
+            # Read data from database into a pandas data frame.
+            df = dbutils.db_to_df(table = table,
+                                  targetdb = targetdb,
+                                  filter_on_wire_break_test = False,
+                                  filter_on_tests = groupdefinition,
+                                  n_to_extract = n_profiles_to_analyse,
+                                  pad=2, 
+                                  XBTbelow=True)
+            testNames = df.columns[2:].values.tolist()
+            
+            # Convert to numpy structures and save copy if first iteration.
+            truth = df['Truth'].to_numpy()
+            tests = []
+            for i, tn in enumerate(testNames):
+                results = df[tn].to_numpy()
+                tests.append(results)
+            cumulative = truth.copy()
+            cumulative[:] = False
+            if iit == 0:
+                alltruth = df['Truth'].to_numpy()
+                alltests = []
+                for i, tn in enumerate(testNames):
+                    results = df[tn].to_numpy()
+                    alltests.append(results)
+                allnames = testNames.copy()
+                    
+            del df # No further need for the data frame.
+
+        # Try to select a QC check to add to the set.
+        if verbose: print('---- Selecting the QC check')
+        if grouptofind == 'any':
+            testnamestosearch = testNames
+        else:
+            testnamestosearch = groupdefinition['At least one from group'][grouptofind]
+
+        # Find the best choice from all the QC tests in this group.
+        bestchoice = ''
+        bestcost   = return_cost(costratio, 0.0, 100.0)    
+        for tn in testnamestosearch:
+            if tn in qclist: continue
+            for itest, name in enumerate(testNames):
+                if name == tn: 
+                    cumulativenew      = np.logical_or(cumulative, tests[itest])
+                    tpr, fpr, fnr, tnr = main.calcRates(cumulativenew, truth)
+                    newcost            = return_cost(costratio, tpr, fpr)
+                    if verbose: print('    ', tpr, fpr, newcost, bestcost, name)
+                    if newcost == bestcost:
+                        if verbose:
+                            print('  ' + bestchoice + ' and ' + name + ' have the same results and the first is kept')
+                    elif newcost < bestcost:
+                        bestchoice = name
+                        bestcost   = newcost
+                        besti      = itest
+                        besttpr    = tpr
+
+        # If selecting from any test, need to ensure that it is worth keeping.
+        if grouptofind == 'any' and bestchoice != '':
+            ctpr, cfpr, cfnr, ctnr = main.calcRates(cumulative, truth)
+            currentcost            = return_cost(costratio, ctpr, cfpr)
+            if (currentcost < bestcost or 
+                (besttpr - ctpr) < improve_threshold):
+                bestchoice = ''
+
+        # Record the choice that is made.
+        if bestchoice == '':
+            if verbose: print('WARNING: no suitable tests in group "' + grouptofind + '", skipping')
+            if grouptofind == 'any':
+                if verbose: print('End of QC test selection')
+                keepgoing = False
+        else:
+            if verbose: print('  ' + bestchoice + ' was selected from group ' + grouptofind)
+            cumulative = np.logical_or(cumulative, tests[besti])
+            qclist.append(bestchoice)
+            groupdefinition['Remove rejected levels'].append(bestchoice)
+            
+        # Increment iit to move on to the next group.
+        iit += 1
+
+    # Create roc.
+    cumulative    = alltruth.copy()
+    cumulative[:] = False
+    r_fprs        = []
+    r_tprs        = []
+    for tn in qclist:
+        found = False
+        for itest, name in enumerate(allnames):
+            if tn == name:
+                cumulative         = np.logical_or(cumulative, alltests[itest])
+                tpr, fpr, fnr, tnr = main.calcRates(cumulative, truth)      
+                r_fprs.append(fpr)
+                r_tprs.append(tpr)
+                print('ROC point: ', tpr, fpr, tn)
+                found = True
+        assert found, 'Error in constructing ROC'
+
+    if plot_roc:
+        plt.plot(r_fprs, r_tprs, 'k')
+        for i in range(len(r_fprs)):
+            colour = 'b'
+            plt.plot(r_fprs[i], r_tprs[i], colour + 'o')
+        plt.xlim(0, 100)
+        plt.ylim(0, 100)
+        plt.xlabel('False positive rate (%)')
+        plt.ylabel('True positive rate (%)')
+        plt.savefig(plot_roc)
+        plt.close()
+
+    if write_roc:
+        f = open(write_roc, 'w')
+        r = {}
+        r['tpr'] = r_tprs
+        r['fpr'] = r_fprs
+        r['tests'] = qclist
+        json.dump(r, f)
+        f.close()
+
 if __name__ == '__main__':
 
     # parse options
-    options, remainder = getopt.getopt(sys.argv[1:], 't:d:n:c:o:p:h')
+    options, remainder = getopt.getopt(sys.argv[1:], 't:d:n:c:o:p:h:sl')
     targetdb = 'iquod.db'
     dbtable = 'iquod'
     outfile = False
     plotfile = False
     samplesize = None
     costratio = [5.0, 5.0]
+    ordered = False
+    levelbased = False
     for opt, arg in options:
         if opt == '-d':
             dbtable = arg
@@ -340,12 +509,18 @@ if __name__ == '__main__':
             outfile = arg
         if opt == '-p':
             plotfile = arg
+        if opt == '-s':
+            ordered = True
+        if opt == '-l':
+            levelbased = True
         if opt == '-h':
             print('usage:')
             print('-d <db table name to read from>')
             print('-t <name of db file>')
             print('-n <number of profiles to consider>')
             print('-c <cost ratio array>')
+            print('-s Find QC tests in a predefined sequence')
+            print('-l If -s, remove only QCed out levels not profiles on each step')
             print('-o <filename to write json results out to>')
             print('-p <filename to write roc plot out to>')
             print('-h print this help message and quit')
@@ -353,5 +528,8 @@ if __name__ == '__main__':
         print('please provide a sample size to consider with the -n flag')
         print('-h to print usage')
 
-    find_roc(table=dbtable, targetdb=targetdb, n_profiles_to_analyse=samplesize, costratio=costratio, plot_roc=plotfile, write_roc=outfile)
+    if ordered:
+        find_roc_ordered(table=dbtable, targetdb=targetdb, n_profiles_to_analyse=samplesize, costratio=costratio, plot_roc=plotfile, write_roc=outfile, levelbased=levelbased)
+    else:
+        find_roc(table=dbtable, targetdb=targetdb, n_profiles_to_analyse=samplesize, costratio=costratio, plot_roc=plotfile, write_roc=outfile)
 

--- a/qctest_groups.csv
+++ b/qctest_groups.csv
@@ -1,7 +1,7 @@
 Test group,Rule,QC test,Comment
 Sensible lat/lon,Remove profile,Argo_impossible_location_test,Non controversial sanity check on location
 Sensible date,Remove profile,Argo_impossible_date_test,Non controversial sanity check on date
-Near surface XBT data,Remove rejected levels,CSIRO_depth,Standard reject of XBT data < 3.6 m
+Near surface XBT data,Remove above reject,CSIRO_depth,Standard reject of XBT data < 3.6 m
 Wire break,Remove below reject,CSIRO_wire_break,Expert opinion is that this is highly reliable at detecting XBT wire breaks
 Depth above surface,Remove rejected levels,ICDC_aqc_01_level_order,Flags depths less than zero (plus preprocessing for other ICDC checks)
 Range,At least one from group,AOML_gross,
@@ -57,3 +57,4 @@ Fuzzy logic,Optional,CoTeDe_Morello2014,
 XBT surface spikes,Optional,CSIRO_surface_spikes,Not a standard spike check; specific to XBTs
 Track check,Optional,EN_track_check,Check on position of successive profiles
 Maximum depth,Optional,ICDC_aqc_04_max_obs_depth,Defines maximum possible depth for instruments and flags data exceeding these
+Min max,Optional,minmax,

--- a/qctest_groups.csv
+++ b/qctest_groups.csv
@@ -57,4 +57,4 @@ Fuzzy logic,Optional,CoTeDe_Morello2014,
 XBT surface spikes,Optional,CSIRO_surface_spikes,Not a standard spike check; specific to XBTs
 Track check,Optional,EN_track_check,Check on position of successive profiles
 Maximum depth,Optional,ICDC_aqc_04_max_obs_depth,Defines maximum possible depth for instruments and flags data exceeding these
-Min max,Optional,minmax,
+Range,At least one from group,minmax,

--- a/qctests/EN_track_check.py
+++ b/qctests/EN_track_check.py
@@ -47,7 +47,7 @@ def test(p, parameters):
     # start all as passing by default
     EN_track_results = {}
     for i in range(len(track_rows)):
-        EN_track_results[track_rows[i][0]] = np.zeros(p.n_levels(), dtype=bool)
+        EN_track_results[track_rows[i][0]] = np.zeros(n_levels_raw(track_rows[i][8][1:-1]), dtype=bool)
 
     # copy the list of headers;
     # remove entries as they are flagged.
@@ -121,6 +121,10 @@ def assess_usability(p):
 def assess_usability_raw(raw):
     p = main.text2wod(raw)
     return assess_usability(p)
+
+def n_levels_raw(raw):
+    p = main.text2wod(raw)
+    return p.n_levels()
 
 def isAircraft(profile):
     '''

--- a/tests/dbutils_validation.py
+++ b/tests/dbutils_validation.py
@@ -6,6 +6,7 @@ import qctests.EN_constant_value_check
 from util import main
 import util.testingProfile
 import numpy
+from util import dbutils
 from util.dbutils import retrieve_existing_qc_result
 
 #####  ---------------------------------------------------
@@ -128,5 +129,48 @@ class TestClass:
         
         assert retrieved_qc is None, 'None not returned if QC not available'
         
-
+    def test_get_n_levels_before_fail(self):
+        '''
+        Test that the correct number of levels before a reject is found.
+        '''
+        
+        qc = [main.pack_array(numpy.array([False, False, True, False])),
+              main.pack_array(numpy.array([False, False, False, False])),
+              main.pack_array(numpy.array([True, True, True, True]))]
+              
+        n = dbutils.get_n_levels_before_fail(qc)
+        
+        expected = [2, 4, 0]
+        
+        assert numpy.array_equal(n, expected), 'Number of levels returned was not as expected'
+         
+    def test_get_reversed_n_levels_before_fail(self):
+        '''
+        Test that the correct number of levels before a reject is found, counting from the bottom.
+        '''
+        
+        qc = [main.pack_array(numpy.array([False, False, True, False])),
+              main.pack_array(numpy.array([False, False, False, False])),
+              main.pack_array(numpy.array([True, True, True, True]))]
+              
+        n = dbutils.get_reversed_n_levels_before_fail(qc)
+        
+        expected = [-1, -4, 0]
+        
+        assert numpy.array_equal(n, expected), 'Number of levels returned was not as expected'
+         
+    def test_check_for_fail(self):
+        '''
+        Test that the correct number of levels before a reject is found, counting from the bottom.
+        '''
+        
+        qc = [main.pack_array(numpy.array([False, False, True, False])),
+              main.pack_array(numpy.array([False, False, False, False])),
+              main.pack_array(numpy.array([True, True, True, True]))]
+              
+        results = dbutils.check_for_fail(qc)
+        
+        expected = [True, False, True]
+        
+        assert numpy.array_equal(results, expected), 'Result not as expected'
         

--- a/util/dbutils.py
+++ b/util/dbutils.py
@@ -219,7 +219,7 @@ def db_to_df(table,
                     # Apply the result of the action.
                     if numpy.count_nonzero(applied == False) == 0:
                         # Completely remove a profile if it has no valid levels after applying the action.
-                        todrop.add(i)
+                        todrop.add(ip)
                     elif numpy.count_nonzero(applied == True) == 0:
                         # Nothing to do as there were no rejected levels.
                         pass

--- a/util/dbutils.py
+++ b/util/dbutils.py
@@ -39,7 +39,11 @@ def get_n_levels_before_fail(results):
     nlevels = []
     for result in results:
         n = 0
-        for qc in unpack_qc(result):
+        if type(result) is numpy.ndarray or type(result) is numpy.ma.core.MaskedArray or type(result) is list:
+            qcresult = result
+        else:
+            qcresult = unpack_qc(result)
+        for qc in qcresult:
             if qc == False:
                 n += 1
             else:
@@ -53,7 +57,11 @@ def get_reversed_n_levels_before_fail(results):
     nlevels = []
     for result in results:
         n = 0
-        for qc in unpack_qc(result)[::-1]:
+        if type(result) is numpy.ndarray or type(result) is numpy.ma.core.MaskedArray or type(result) is list:
+            qcresult = result
+        else:
+            qcresult = unpack_qc(result)
+        for qc in qcresult[::-1]:
             if qc == False:
                 n -= 1
             else:
@@ -68,7 +76,11 @@ def check_for_fail(results):
     fails = []
     for result in results:
         answer = False
-        for qc in unpack_qc(result):
+        if type(result) is numpy.ndarray or type(result) is numpy.ma.core.MaskedArray or type(result) is list:
+            qcresult = result
+        else:
+            qcresult = unpack_qc(result)
+        for qc in qcresult:
             if qc == True:
                 answer = True
                 break
@@ -79,6 +91,46 @@ def check_for_fail(results):
 def unpack_qc_results(results):
 
     return [unpack_qc(result) for result in results] 
+
+def qc_action(action, qc, pad=0):
+    '''
+    Applies action to the qc results with padding
+    '''
+    # Define results array.
+    result = unpack_qc(qc)
+
+    # Apply the action.
+    if action == 'Remove above reject':
+        nlevels = get_reversed_n_levels_before_fail([result])[0]
+        if nlevels == 0:
+            result[:] = True
+        else:
+            result[:nlevels] = True
+    elif action == 'Remove below reject':
+        nlevels = get_n_levels_before_fail([result])[0]
+        if nlevels == 0:
+            result[:] = True
+        else:
+            result[nlevels+1:] = True
+    elif action == 'Remove profile':
+        result[:] = check_for_fail([result])[0]
+    elif action == 'Remove rejected levels':
+        pass # Keep the original QC results.
+    else:
+        raise NameError('Unrecognised action: ' + action)
+        
+    # Add padding if required.
+    if (pad > 0):
+        resultorig = result.copy()
+        for ipad, qcpad in enumerate(resultorig):
+            if qcpad:
+                ipadstart = max(0, ipad - pad)
+                ipadend   = min(len(result), ipad + pad + 1)
+                result[ipadstart:ipadend] = True
+
+    # Return the result, which has True where levels should be removed
+    # and False where levels should be kept.
+    return result
 
 def db_to_df(table,
              filter_on_wire_break_test=False, 
@@ -117,99 +169,89 @@ def db_to_df(table,
 
     cur.execute(query)
     rawresults = cur.fetchall()
+    
+    # ensure XBT wire breaks handling is set up by adding it to the
+    # filter_on_tests['Remove below reject'] group
+    if filter_on_wire_break_test:
+        if 'Remove below reject' in filter_on_tests.keys():
+            if 'CSIRO_wire_break' not in filter_on_tests['Remove below reject']:
+                filter_on_tests['Remove below reject'].append('CSIRO_wire_break')
+        else:
+            filter_on_tests['Remove below reject'] = ['CSIRO_wire_break']
 
-    sub = 1000
+    # Loop over the profiles, 1000 profiles at a time.
+    sub  = 1000 # Number of profiles to process at a time.
+    nsub = math.ceil(len(rawresults)/sub) # Number of batches of 1000 profiles there will be.
     df_final = None
-    testNamesSave = testNames
-    for i in range(math.ceil(len(rawresults)/sub)):
-        df = pandas.DataFrame(rawresults[i*sub:(i+1)*sub]).astype('bytes')
-        df.columns = ['uid', 'Truth'] + testNamesSave + ['probe']
+    testNamesSave = testNames.copy()
+    for i in range(nsub):
+        # Define the start and end points of this batch of profiles and create a dataframe from them.
+        istart = i * sub
+        iend   = min((i + 1) * sub, len(rawresults))
+        df = pandas.DataFrame(rawresults[istart:iend]).astype('bytes')
+        df.columns = ['uid', 'Truth'] + testNamesSave + ['probe'] # Probe is needed for XBTbelow functionality.
         df = df.astype({'uid': 'int'})
         df = df.astype({'probe': 'float'})
-        if filter_on_wire_break_test:
-            nlevels = get_n_levels_before_fail(df['CSIRO_wire_break'])
-            del df['CSIRO_wire_break'] # No use for this now.
-            df.reset_index(inplace=True, drop=True)
-            testNames = df.columns[2:-1].values.tolist()
-            for i in range(len(df.index)):
-                for j in range(1, len(df.columns) - 1):
-                    qc = unpack_qc(df.iloc[i, j])
-                    df.iat[i, j] = main.pack_array(qc)
 
+        # todrop stores a set of profiles that are completely removed by any actions we apply.
         todrop = set()
         for action in filter_on_tests:
-            # Check if the action is relevant.
+            # Check if the action requires any processing.
             if action == 'Optional' or action == 'At least one from group': continue
 
-            # Initialise variables.
-            nlevels   = -1
-            outcomes  = False
-            qcresults = []
+            # Loop over the tests that will have this action applied.
             for testname in filter_on_tests[action]:
-                for i in range(0, len(df.index)):
-                    if action == 'Remove above reject':
-                        nlevels = get_reversed_n_levels_before_fail([df[testname][i]])[0]
-                        if pad > 0:
-                            nlevels += pad
-                            if nlevels > 0: nlevels = 0
-                    elif action == 'Remove below reject':
-                        nlevels = get_n_levels_before_fail([df[testname][i]])[0]
-                        if pad > 0:
-                            nlevels -= pad
-                            if nlevels < 0: nlevels = 0
-                    elif action == 'Remove profile':
-                        outcomes = check_for_fail([df[testname][i]])[0]
-                    elif action == 'Remove rejected levels':
-                        qcresults = unpack_qc_results([df[testname][i]])[0]
-                        if (pad > 0) or XBTbelow:
-                            qcresultsorig = qcresults.copy()
-                            for icons, qccons in enumerate(qcresultsorig):
-                                if qccons:
-                                    iconsstart = max(0, icons - pad)
-                                    iconsend   = min(len(qcresults), icons + pad + 1)
-                                    if XBTbelow:
-                                        if df['probe'][i] == 2:
-                                            iconsend = len(qcresults)
-                                    qcresults[iconsstart:iconsend] = True
-                    else:
-                        raise NameError('Unrecognised action: ' + action)
+            
+                # Loop over the profiles, a.        
+                for ip in range(len(df.index)):
 
-                    if (((action == 'Remove above reject' or action == 'Remove below reject') and nlevels == 0) or
-                        (action == 'Remove profile' and outcomes == True) or
-                        (action == 'Remove rejected levels' and numpy.count_nonzero(qcresults == False) == 0)):
-                        # Completely remove a profile if it has no valid levels or if it
-                        # has a fail and the action is to remove.
+                    # If XBTbelow is set, the Remove rejected levels action is replaced with
+                    # Remove below reject for XBT profiles.
+                    actiontoapply = action
+                    if XBTbelow and (df['probe'][ip] == 2) and (action == 'Remove rejected levels'):
+                        actiontoapply = 'Remove below reject'
+
+                    # Use the qc_action function to apply the action.
+                    applied = qc_action(actiontoapply,
+                                        df[testname][ip],  
+                                        pad)
+
+                    # Apply the result of the action.
+                    if numpy.count_nonzero(applied == False) == 0:
+                        # Completely remove a profile if it has no valid levels after applying the action.
                         todrop.add(i)
-                    elif (action != 'Remove profile'):
+                    elif numpy.count_nonzero(applied == True) == 0:
+                        # Nothing to do as there were no rejected levels.
+                        pass
+                    else:
                         for j in range(1, len(df.columns) - 1):
                             # Retain only the levels that passed testname.
-                            # Some QC tests may return only one value so check for this.
-                            qc = unpack_qc(df.iloc[i, j])
-                            if action == 'Remove above reject':
-                                qc = qc[nlevels:]
-                            elif action == 'Remove below reject':
-                                qc = qc[:nlevels] 
-                            elif action == 'Remove rejected levels':
-                                qc = qc[qcresults == False]            
-                            df.iat[i, j] = main.pack_array(qc)
+                            qc = unpack_qc(df.iloc[ip, j])
+                            qc = qc[applied == False]            
+                            df.iat[ip, j] = main.pack_array(qc)
 
                 del df[testname] # No need to keep this any longer.
                 df.reset_index(inplace=True, drop=True)
-                
+        
+        # Drop the profiles that no longer have any valid levels.        
         todrop = list(todrop)
         if len(todrop) > 0:
             df.drop(todrop, inplace=True)
         df.reset_index(inplace=True, drop=True)
         testNames = df.columns[2:-1].values.tolist()
+        
+        # Apply the parse if required.
         if applyparse:
             df[['Truth']] = df[['Truth']].apply(parse_truth)
             df[testNames] = df[testNames].apply(parse)
 
+        # Keep the results.
         if i == 0:
             df_final = df
         else:
             df_final = pandas.concat([df_final, df])
     
+    # Remove the probe column before returning.
     del df_final['probe']
     return df_final.reset_index(drop=True)
     


### PR DESCRIPTION
Updates mainly to the analysis routines. In particular:
 
- Add in a simpler version of the code in analyse-results.py. Apart from simplifying the code, the main difference is to force selection of QC checks in a particular order e.g. pick a range check, then a climatology check etc. This was implemented following feedback from colleagues.
- Implement two extra features in db_to_df:
    1) When removing levels flagged by a particular test, allow additional levels around the flagged level to be removed also. This handles the situator where a QC operator or automatic QC test makes slightly different decisions on which levels to flag for the same issue.
    2) Allow removal of levels deeper than a rejected level if it is an XBT. This may be done as once an XBT fails, the rest of the profile may be thought of as suspect.
- Fix minor issues due to change in syntax in the latest version of pandas.